### PR TITLE
Adds "npm install" to README's Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ Development
 Use grunt to build and lint the code:
 
 ```bash
+# Install Grunt and development dependencies
+npm install 
+
 # Default task - validates with jshint and minifies source
 grunt
 


### PR DESCRIPTION
I suggest adding "npm install" as the first step in the build process since a package.json is included, we should recommend it be used :)
