### PR TITLE
Update Ember CLI keyword.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/firebase/emberFire/issues"
   },
   "keywords": [
-    "ember-cli-addon",
+    "ember-addon",
     "firebase"
   ],
   "devDependencies": {


### PR DESCRIPTION
We are moving from `ember-cli-addon` to `ember-addon`.

See https://github.com/stefanpenner/ember-cli/issues/1064.
