### PR TITLE
clean up after findAll adapter test

### DIFF
--- a/test/tests/adapter.js
+++ b/test/tests/adapter.js
@@ -231,10 +231,14 @@ describe("FirebaseAdapter", function() {
       });
     });
 
-    after(function() {
+    after(function(done) {
       getRefSpy.restore();
       findAllAddEventListenersSpy.restore();
       handleChildValueSpy.restore();
+      Ember.run(function() {
+        store.getById('post', 'post_3').destroyRecord();
+        done();
+      });
     });
 
   });
@@ -297,7 +301,7 @@ describe("FirebaseAdapter", function() {
       it("contains a null belongsTo relationship", function() {
         assert.equal(serializedRecord.user, null);
       });
-      
+
       it("removed the null belongsTo reference from the final payload", function() {
         assert(Ember.isNone(finalPayload.user));
       });

--- a/test/tests/serializer.js
+++ b/test/tests/serializer.js
@@ -105,7 +105,7 @@ describe("FirebaseSerializer", function() {
       });
 
       it("was called for each item in the payload", function() {
-        assert.equal(spy.callCount, 3);
+        assert.equal(spy.callCount, 2);
       });
 
       after(function() {


### PR DESCRIPTION
remove added data during findAll adapter test so that the extractSingle serializer test can run independently.
