### PR TITLE
Respect bower config directory preference

### DIFF
--- a/lib/ember-cli-ember-fire.js
+++ b/lib/ember-cli-ember-fire.js
@@ -2,6 +2,7 @@
 
 var path = require('path');
 var fs   = require('fs');
+var bowerPath = require('bower-config').read().directory;
 
 function EmberCLIEmberFire(project) {
   this.project = project;
@@ -19,7 +20,7 @@ EmberCLIEmberFire.prototype.treeFor = function treeFor(name) {
   var treePath =  path.join('node_modules', 'emberFire', name);
 
   if (!this.emberFireIncluded) {
-    this.app.import('vendor/emberfire/dist/emberfire.js');
+    this.app.import(bowerPath + '/emberfire/dist/emberfire.js');
     this.emberFireIncluded = true;
   }
 
@@ -32,7 +33,7 @@ EmberCLIEmberFire.prototype.treeFor = function treeFor(name) {
 EmberCLIEmberFire.prototype.included = function included(app) {
   this.app = app;
 
-  this.app.import('vendor/firebase/firebase.js');
+  this.app.import(bowerPath + '/firebase/firebase.js');
 };
 
 module.exports = EmberCLIEmberFire;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "main": "lib/ember-cli-ember-fire.js"
   },
   "dependencies": {
+    "bower-config": "^0.5.2"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
ember-cli [changed back](https://github.com/stefanpenner/ember-cli/commit/fc0829630d8ad3eebc36ddbf6f570796d0b1ce55) to `bower_components` dir and in case they change their mind or someone else wants to use it with a previous version, etc, this PR looks up the correct directory dynamically instead.
