### PR TITLE
[BUGFIX] fixes broken hasMany serializations for ED beta.10

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -115,7 +115,7 @@
     serializeHasMany: function(record, json, relationship) {
       var key = relationship.key;
       var payloadKey = this.keyForRelationship ? this.keyForRelationship(key, "hasMany") : key;
-      var relationshipType = DS.RelationshipChange.determineRelationshipType(record.constructor, relationship);
+      var relationshipType = record.constructor.determineRelationshipType(relationship);
       var relationshipTypes = ['manyToNone', 'manyToMany', 'manyToOne'];
 
       if (relationshipTypes.indexOf(relationshipType) > -1) {


### PR DESCRIPTION
**Since emberfire lists `1.0.0-beta.8` as it's ember-data dependency, I assume this can't be merged yet.**

ED's relationship code went through some **major** refactoring for very good reasons, [outlined here](https://github.com/emberjs/data/pull/2208).

I'm still testing, but the most obvious issue is that `hasMany` relationships [depend](https://github.com/firebase/emberfire/blob/master/src/data.js#L118) on `DS.RelationshipChange`, which was removed from ED.

I'm not sure if emberfire's strategy for maintaining backwards compatibility with older ED versions? This PR will not work with `<=beta.9`, but it would be pretty trivial to keep it by just checking for `DS.RelationshipChange` and using the older method. LMK and I can mod.
