### PR TITLE
Add simple "Loading..." message to post list

### DIFF
--- a/examples/blog/index.html
+++ b/examples/blog/index.html
@@ -97,6 +97,10 @@
     </ul>
   </script>
 
+  <script type="text/x-handlebars" data-template-name="posts/loading">
+    <h1>Loading posts...</h1>
+  </script>
+
   <script type="text/x-handlebars" data-template-name="posts/new">
     <h2>New Post</h2>
     <ul class="post-publish">


### PR DESCRIPTION
It can take several seconds for the posts to display (due to the large number of them), so this adds a simple loading indicator.
![FireBlog Loading Indicator](http://i.dstaley.com/FireBlog_2014-09-30_17-34-41.jpg)

You can demo this pull request [here](http://i.dstaley.com/blog-lato/#/posts).
