### PR TITLE
Changed main in package.json and bower.json to unminified file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "realtime",
     "ember-addon"
   ],
-  "main": "dist/emberfire.min.js",
+  "main": "dist/emberfire.js",
   "ignore": [
     "**/.*",
     "src",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "realtime",
     "ember-addon"
   ],
-  "main": "dist/emberfire.min.js",
+  "main": "dist/emberfire.js",
   "files": [
     "lib/**/*",
     "dist/**/*",


### PR DESCRIPTION
@sararob - Please review and merge. After [much discussion and debate on this topic over on the AngularFire repo](https://github.com/firebase/angularfire/issues/436), I now believe we should be including the unminified files as `main` in the `package.json` and `bower.json`.
