### PR TITLE
Use firebase-debug.js in dev builds

### DIFF
--- a/lib/ember-addon/index.js
+++ b/lib/ember-addon/index.js
@@ -13,8 +13,8 @@ module.exports = {
     this._super.included(app);
 
     this.app.import({
-      development: app.bowerDirectory + '/firebase/firebase.js',
-      production: app.bowerDirectory + '/firebase/firebase-debug.js'
+      development: app.bowerDirectory + '/firebase/firebase-debug.js',
+      production: app.bowerDirectory + '/firebase/firebase.js'
     });
 
     this.app.import({


### PR DESCRIPTION
Use the non-minified Firebase lib in dev mode. It seems the original config was accidentally inverted.