### PR TITLE
basic findQuery support

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -23,4 +23,17 @@ app.import('vendor/sinon/shim.js', {
   }
 });
 
+app.import('bower_components/mockfirebase/browser/mockfirebase.js', {
+  type: 'test'
+});
+
+app.import('vendor/mockfirebase/shim.js', {
+  type: 'test',
+  exports: {
+    'mock-firebase': [
+      'default'
+    ]
+  }
+});
+
 module.exports = app.toTree();

--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -211,12 +211,19 @@ export default DS.Adapter.extend(Ember.Evented, {
   },
 
   applyQueryToRef: function (ref, query) {
-    if (!query.orderBy || query.orderBy === '_key') {
+
+    if (!query.orderBy) {
+      query.orderBy = '_key';
+    }
+
+    if (query.orderBy === '_key'){
       ref = ref.orderByKey();
-    } else if (query.orderBy && query.orderBy !== '_priority') {
-      ref = ref.orderByChild(query.orderBy);
-    } else {
+    } else if (query.orderBy === '_value') {
+      ref = ref.orderByValue();
+    } else if (query.orderBy === '_priority') {
       ref = ref.orderByPriority();
+    } else {
+      ref.orderByChild(query.orderBy);
     }
 
     ['limitToFirst', 'limitToLast', 'startAt', 'endAt', 'equalTo'].forEach(function (key) {

--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -185,6 +185,57 @@ export default DS.Adapter.extend(Ember.Evented, {
     }, fmt('DS: FirebaseAdapter#findAll %@ to %@', [type, ref.toString()]));
   },
 
+  findQuery: function(store, type, query) {
+    var adapter = this;
+    var ref = this._getRef(type);
+
+    if (!query.orderBy || query.orderBy === '_key') {
+      ref = ref.orderByKey();
+    } else if (query.orderBy && query.orderBy !== '_priority') {
+      ref = ref.orderByChild(query.orderBy);
+    } else {
+      ref = ref.orderByPriority();
+    }
+
+    if (query.limitToFirst && query.limitToFirst >= 0) {
+      ref = ref.limitToFirst(query.limitToFirst);
+    }
+
+    if (query.limitToLast && query.limitToLast >= 0) {
+      ref = ref.limitToLast(query.limitToLast);
+    }
+
+    if (query.startAt) {
+      ref = ref.startAt(query.startAt);
+    }
+
+    if (query.endAt) {
+      ref = ref.endAt(query.endAt);
+    }
+
+    if (query.equalTo) {
+      ref = ref.equalTo(query.equalTo);
+    }
+
+    return new Promise(function(resolve, reject) {
+      // Listen for child events on the type
+      ref.once('value', function(snapshot) {
+        if (!adapter._findAllHasEventsForType(type)) {
+          adapter._findAllAddEventListeners(store, type, ref);
+        }
+        var results = [];
+        snapshot.forEach(function(childSnapshot) {
+          var payload = adapter._assignIdToPayload(childSnapshot);
+          adapter._updateRecordCacheForType(type, payload);
+          results.push(payload);
+        });
+        resolve(results);
+      }, function(error) {
+        reject(error);
+      });
+    }, fmt('DS: FirebaseAdapter#findQuery %@ with %@', [type, query]));
+  },
+
   /**
     Keep track of what types `.findAll()` has been called for
     so duplicate listeners aren't added

--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -189,33 +189,7 @@ export default DS.Adapter.extend(Ember.Evented, {
     var adapter = this;
     var ref = this._getRef(type);
 
-    if (!query.orderBy || query.orderBy === '_key') {
-      ref = ref.orderByKey();
-    } else if (query.orderBy && query.orderBy !== '_priority') {
-      ref = ref.orderByChild(query.orderBy);
-    } else {
-      ref = ref.orderByPriority();
-    }
-
-    if (query.limitToFirst && query.limitToFirst >= 0) {
-      ref = ref.limitToFirst(query.limitToFirst);
-    }
-
-    if (query.limitToLast && query.limitToLast >= 0) {
-      ref = ref.limitToLast(query.limitToLast);
-    }
-
-    if (query.startAt) {
-      ref = ref.startAt(query.startAt);
-    }
-
-    if (query.endAt) {
-      ref = ref.endAt(query.endAt);
-    }
-
-    if (query.equalTo) {
-      ref = ref.equalTo(query.equalTo);
-    }
+    ref = this.applyQueryToRef(ref, query);
 
     return new Promise(function(resolve, reject) {
       // Listen for child events on the type
@@ -234,6 +208,24 @@ export default DS.Adapter.extend(Ember.Evented, {
         reject(error);
       });
     }, fmt('DS: FirebaseAdapter#findQuery %@ with %@', [type, query]));
+  },
+
+  applyQueryToRef: function (ref, query) {
+    if (!query.orderBy || query.orderBy === '_key') {
+      ref = ref.orderByKey();
+    } else if (query.orderBy && query.orderBy !== '_priority') {
+      ref = ref.orderByChild(query.orderBy);
+    } else {
+      ref = ref.orderByPriority();
+    }
+
+    ['limitToFirst', 'limitToLast', 'startAt', 'endAt', 'equalTo'].forEach(function (key) {
+      if (query[key] || query[key] === '') {
+        ref = ref[key](query[key]);
+      }
+    });
+
+    return ref;
   },
 
   /**

--- a/bower.json
+++ b/bower.json
@@ -46,6 +46,7 @@
     "moment": "2.5.1",
     "blueimp-md5": "1.0.1",
     "normalize-css": "2.1.3",
-    "sinon": "http://sinonjs.org/releases/sinon-1.12.2.js"
+    "sinon": "http://sinonjs.org/releases/sinon-1.12.2.js",
+    "mockfirebase": "~0.10.2"
   }
 }

--- a/tests/unit/adapters/firebase-test.js
+++ b/tests/unit/adapters/firebase-test.js
@@ -4,6 +4,9 @@ import {
   it
 } from 'ember-mocha';
 
+import MockFirebase from 'mock-firebase';
+import sinon from 'sinon';
+
 describeModule('adapter:firebase', 'FirebaseAdapter', {
     // Specify the other units that are required for this test.
     // needs: ['serializer:foo']
@@ -16,6 +19,95 @@ describeModule('adapter:firebase', 'FirebaseAdapter', {
         assert.throws(function() {
           this.subject();
         });
+      });
+
+    });
+
+    describe('#applyQueryToRef', function () {
+      var mockFirebase, adapter, ref;
+
+      beforeEach(function () {
+        mockFirebase = new MockFirebase('https://emberfire-demo.firebaseio.com');
+        adapter = this.subject({
+          firebase: mockFirebase
+        });
+        ref = mockFirebase.ref();
+        // mock ref doesnt support the new query stuff, yet
+        ref.orderByKey = function () { return this; };
+        ref.orderByPriority = function () { return this; };
+        ref.orderByChild = function () { return this; };
+        ref.limitToFirst = function () { return this; };
+        ref.limitToLast = function () { return this; };
+        ref.startAt = function () { return this; };
+        ref.endAt = function () { return this; };
+        ref.equalTo = function () { return this; };
+      });
+
+      it('defaults to orderByKey', function () {
+        var spy = sinon.spy(ref, 'orderByKey');
+
+        adapter.applyQueryToRef(ref, {});
+        assert(spy.calledOnce, 'orderByKey should be called');
+      });
+
+      it('orderBy: `_key` calls orderByKey', function () {
+        var spy = sinon.spy(ref, 'orderByKey');
+
+        adapter.applyQueryToRef(ref, { orderBy: '_key' });
+        assert(spy.calledOnce, 'orderByKey should be called');
+      });
+
+      it('orderBy: `_priority` calls orderByPriority', function () {
+        var spy = sinon.spy(ref, 'orderByPriority');
+
+        adapter.applyQueryToRef(ref, { orderBy: '_priority' });
+        assert(spy.calledOnce, 'orderByPriority should be called');
+      });
+
+      it('orderBy: `x` calls orderByChild(x)', function () {
+        var spy = sinon.spy(ref, 'orderByChild');
+
+        adapter.applyQueryToRef(ref, { orderBy: 'x' });
+        assert(spy.calledWith('x'), 'orderByChild should be called with `x`');
+      });
+
+      ['limitToFirst', 'limitToLast', 'startAt', 'endAt', 'equalTo'].forEach(function (key) {
+
+        it(`calls ${key} and passes through value when specified`, function () {
+          var spy = sinon.spy(ref, key);
+
+          var query = {};
+
+          query[key] = 'value';
+
+          adapter.applyQueryToRef(ref, query);
+          assert(spy.calledOnce);
+          assert(spy.calledWith('value'));
+        });
+
+        it(`calls ${key} and passes through value when empty string`, function () {
+          var spy = sinon.spy(ref, key);
+
+          var query = {};
+
+          query[key] = '';
+
+          adapter.applyQueryToRef(ref, query);
+          assert(spy.calledOnce);
+          assert(spy.calledWith(''));
+        });
+
+        it(`does not call ${key} when the value is null`, function () {
+          var spy = sinon.spy(ref, key);
+
+          var query = {};
+
+          query[key] = null;
+
+          adapter.applyQueryToRef(ref, query);
+          assert(spy.called === false, `${key} should not be called`);
+        });
+
       });
 
     });

--- a/tests/unit/adapters/firebase-test.js
+++ b/tests/unit/adapters/firebase-test.js
@@ -35,6 +35,7 @@ describeModule('adapter:firebase', 'FirebaseAdapter', {
         // mock ref doesnt support the new query stuff, yet
         ref.orderByKey = function () { return this; };
         ref.orderByPriority = function () { return this; };
+        ref.orderByValue = function () { return this; };
         ref.orderByChild = function () { return this; };
         ref.limitToFirst = function () { return this; };
         ref.limitToLast = function () { return this; };
@@ -43,25 +44,30 @@ describeModule('adapter:firebase', 'FirebaseAdapter', {
         ref.equalTo = function () { return this; };
       });
 
-      it('defaults to orderByKey', function () {
+      it('defaults to orderByKey when orderBy is not supplied', function () {
         var spy = sinon.spy(ref, 'orderByKey');
 
         adapter.applyQueryToRef(ref, {});
         assert(spy.calledOnce, 'orderByKey should be called');
       });
 
-      it('orderBy: `_key` calls orderByKey', function () {
+      it('defaults to orderByKey when orderBy is an empty string', function () {
         var spy = sinon.spy(ref, 'orderByKey');
 
-        adapter.applyQueryToRef(ref, { orderBy: '_key' });
+        adapter.applyQueryToRef(ref, { orderBy: '' });
         assert(spy.calledOnce, 'orderByKey should be called');
       });
 
-      it('orderBy: `_priority` calls orderByPriority', function () {
-        var spy = sinon.spy(ref, 'orderByPriority');
+      ['key', 'value', 'priority'].forEach(function (k) {
+        var upperK = k.capitalize();
 
-        adapter.applyQueryToRef(ref, { orderBy: '_priority' });
-        assert(spy.calledOnce, 'orderByPriority should be called');
+        it(`orderBy: "_${k}" calls orderBy${upperK}`, function () {
+          var spy = sinon.spy(ref, 'orderBy' + upperK);
+
+          adapter.applyQueryToRef(ref, { orderBy: '_' + k });
+          assert(spy.calledOnce, `orderBy${upperK} should be called`);
+        });
+
       });
 
       it('orderBy: `x` calls orderByChild(x)', function () {

--- a/vendor/mockfirebase/shim.js
+++ b/vendor/mockfirebase/shim.js
@@ -1,0 +1,9 @@
+/* globals Firebase */
+
+define('mock-firebase', [], function() {
+  "use strict";
+
+  return {
+    'default': MockFirebase
+  };
+});


### PR DESCRIPTION
First draft at `findQuery` support.  I've simply mapped the underlying Firebase query methods.

Syntax:

```js
// order by key
this.store.find('user', {
  orderBy: '_key', // default if omitted, also '_priority' is available
  limitToFirst: 10,
  startAt: '-JftjvGEXxoWX15S9l-t'
})
```

```js
// order by child prop
this.store.find('user', {
  orderBy: 'lastName',
  limitToLast: 10,
  endAt: 'Wells'
})
```

- [x] discuss query syntax (mainly the `orderBy` bit)
- [x] tests (although similar to `findAll`, needs tests for the query object mapping)
- [x] code cleanup (needs more DRY)
- [ ] providing we're happy, write some docs

/cc @jayphelps @sararob 