### PR TITLE
Loosen ember version requirement (ember-data is fine with 1.7+)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,9 +35,9 @@
   ],
   "dependencies": {
     "firebase": "2.1.x",
-    "ember": "1.9.x",
     "ember-data": "1.0.0-beta.12"
   },
   "devDependencies": {
+    "ember": "1.9.x"
   }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,1 +1,2 @@
+feature - Loosen Ember version requirement to 1.7+ to be compatible with new ember-cli apps.
 fixed - Deleting a record now removes orphaned `hasMany` relationship links.


### PR DESCRIPTION
A new `ember-cli` app installs `ember#1.8.1`, bower will complain when managing dependencies until you bump to 1.9.x (which also wants `handlebars` 2.0.0). This weakens the ember requirement to use whatever `ember-data` needs (in this case 1.7.x), making for less friction on a new `ember-cli` app.