### PR TITLE
Loosen ember-data version requirement

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "firebase": "2.1.x",
-    "ember-data": "1.0.0-beta.12"
+    "ember-data": ">=1.0.0-beta.11 <1.0.0-beta.15"
   },
   "devDependencies": {
     "ember": "1.9.1",

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,2 +1,3 @@
+changed - Allow Ember Data versions `1.0.0.beta.11` through `beta.14.x`.
 fixed - Use `EnumerableUtils` methods for Ember configs with `EXTEND_PROTOTYPES` set to false.
 important - EmberFire uses es6 modules. Please check the documentation on updated usage info.


### PR DESCRIPTION
Tested on `beta.11` through `beta.14.1`. 

`beta.15` throws deprecation warnings due to the [snapshot changes](http://emberjs.com/blog/2015/02/14/ember-data-1-0-beta-15-released.html#toc_snapshot-api).