### PR TITLE
Adds a firebase-adapter blueprint and environment

### DIFF
--- a/blueprints/emberfire/index.js
+++ b/blueprints/emberfire/index.js
@@ -1,6 +1,8 @@
 /* jshint node: true */
 'use strict';
 
+var EOL         = require('os').EOL;
+
 module.exports = {
   normalizeEntityName: function() {
     // this prevents an error when the entityName is
@@ -8,7 +10,20 @@ module.exports = {
     // to us
   },
 
-  afterInstall: function() {
-    return this.addBowerPackageToProject('firebase', '~2.1.0');
+  availableOptions: [
+    { name: 'url', type: String }
+  ],
+
+  afterInstall: function(options) {
+    var firebaseUrl = options.url || 'https://YOUR-FIREBASE-NAME.firebaseio.com/';
+    return this.addBowerPackagesToProject([
+      {name: 'emberfire', target: "~0.0.0"}
+    ]).then(function() {
+      return this.insertIntoFile(
+        'config/environment.js',
+        '    firebase: \'' + firebaseUrl + '\',',
+        {after: '    locationType: \'auto\',' + EOL}
+      );
+    }.bind(this));
   }
 };

--- a/blueprints/firebase-adapter/files/app/adapters/__name__.js
+++ b/blueprints/firebase-adapter/files/app/adapters/__name__.js
@@ -1,0 +1,7 @@
+import config from '../config/environment';
+import Firebase from 'firebase';
+import FirebaseAdapter from 'emberfire/adapters/firebase';
+
+export default <%= baseClass %>.extend({
+  firebase: new Firebase(<%= firebaseUrl %>)
+});

--- a/blueprints/firebase-adapter/index.js
+++ b/blueprints/firebase-adapter/index.js
@@ -1,0 +1,20 @@
+var inflection = require('inflection');
+
+module.exports = {
+  description: 'Generates a firebase adapter.',
+
+  locals: function(options) {
+    var firebaseUrl     = 'config.firebase';
+    var adapterName     = options.entity.name;
+    var baseClass       = 'FirebaseAdapter';
+
+    if (adapterName !== 'application') {
+      firebaseUrl = "config.firebase + '/" + inflection.pluralize(adapterName) + "'";
+    }
+
+    return {
+      baseClass: baseClass,
+      firebaseUrl: firebaseUrl
+    };
+  }
+};

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+feature - The default generator adds firebase to `config/environments.js`
+feature - A blueprint for generating firebase adapters
 changed - Removed `emberfire` bower dependency from `ember-cli` projects, only `firebase` is needed.
 changed - Allow Ember Data versions `1.0.0.beta.11` through `beta.14.x`.
 fixed - Use `EnumerableUtils` methods for Ember configs with `EXTEND_PROTOTYPES` set to false.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "gulp-es6-module-transpiler": "^0.2.1",
     "gulp-jshint": "^1.9.2",
     "gulp-sourcemaps": "^1.3.0",
-    "gulp-uglify": "^1.1.0"
+    "gulp-uglify": "^1.1.0",
+    "inflection": "^1.6.0"
   }
 }


### PR DESCRIPTION
Why:

* It should be simplier to get starting using firebase in an ember application.

This PR:

* makes the default generator override the `config/environment.js` file
to include the firebase url.

* Creates a blueprint for generating adapters:

Usage is `ember generate firebase-adapter name` which will generate an adapter
that extends from `FirebaseAdapter`.

`ember generate firebase-adapter application` produces:

```javascript
// app/adapters/application.js
import config from '../config/environment';
import Firebase from 'firebase';
import FirebaseAdapter from 'emberfire/adapters/firebase';

export default FirebaseAdapter.extend({
  firebase: new Firebase(config.firebase)
});
```

`ember generate firebase-adapter post` produces:

```javascript
// app/adapters/post.js
import config from '../config/environment';
import Firebase from 'firebase';
import FirebaseAdapter from 'emberfire/adapters/firebase';

export default FirebaseAdapter.extend({
  firebase: new Firebase(config.firebase + '/posts')
});
```