### PR TITLE
Allow future firebase versions compatibility with 2.1.x+

### DIFF
--- a/blueprints/emberfire/index.js
+++ b/blueprints/emberfire/index.js
@@ -9,6 +9,6 @@ module.exports = {
   },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('emberfire', '~0.0.0');
+    return this.addBowerPackageToProject('firebase', '^2.1.0');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "package.json"
   ],
   "dependencies": {
-    "firebase": "2.1.x",
+    "firebase": "^2.1.0",
     "ember-data": ">=1.0.0-beta.11 <1.0.0-beta.15"
   },
   "devDependencies": {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+changed - Removed `emberfire` bower dependency from `ember-cli` projects, only `firebase` is needed.
+changed - Allow Firebase `2.2+` versions.
 changed - Allow Ember Data versions `1.0.0.beta.11` through `beta.14.x`.
 fixed - Use `EnumerableUtils` methods for Ember configs with `EXTEND_PROTOTYPES` set to false.
 important - EmberFire uses es6 modules. Please check the documentation on updated usage info.


### PR DESCRIPTION
- Allows firebase versions with semver compatibility to `2.1.0` (e.g. `2.2.x`)
- `ember-cli` projects do not need to include `emberfire` as a bower dependency anymore, everything is included directly as es6 modules.