### PR TITLE
Default generator improvements

### DIFF
--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,4 @@
+{
+  "extends": "../.jshintrc",
+  "node": true
+}

--- a/blueprints/emberfire/files/app/adapters/application.js
+++ b/blueprints/emberfire/files/app/adapters/application.js
@@ -1,0 +1,7 @@
+import config from '../config/environment';
+import Firebase from 'firebase';
+import FirebaseAdapter from 'emberfire/adapters/firebase';
+
+export default FirebaseAdapter.extend({
+  firebase: new Firebase(config.firebase)
+});

--- a/blueprints/emberfire/index.js
+++ b/blueprints/emberfire/index.js
@@ -17,7 +17,7 @@ module.exports = {
   afterInstall: function(options) {
     var firebaseUrl = options.url || 'https://YOUR-FIREBASE-NAME.firebaseio.com/';
     return this.addBowerPackagesToProject([
-      {name: 'emberfire', target: "~0.0.0"}
+      {name: 'firebase', target: "~2.1.0"}
     ]).then(function() {
       return this.insertIntoFile(
         'config/environment.js',

--- a/blueprints/emberfire/index.js
+++ b/blueprints/emberfire/index.js
@@ -1,7 +1,7 @@
-/* jshint node: true */
 'use strict';
 
 var EOL         = require('os').EOL;
+var chalk       = require('chalk');
 
 module.exports = {
   normalizeEntityName: function() {
@@ -24,6 +24,10 @@ module.exports = {
         '    firebase: \'' + firebaseUrl + '\',',
         {after: '    locationType: \'auto\',' + EOL}
       );
-    }.bind(this));
+    }.bind(this)).then(function () {
+      var output = EOL;
+      output += chalk.yellow('EmberFire') + ' has been installed. Please configure your firebase URL in ' + chalk.green('config/environment.js') + EOL;
+      console.log(output);
+    });
   }
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
+    "chalk": "^1.0.0",
     "del": "^1.1.1",
     "ember-cli": "0.1.15",
     "ember-cli-6to5": "^3.0.0",


### PR DESCRIPTION
- create `app/adapters/application.js` with default generator
- fix regression, install firebase bower dep, not emberfire
- print console instructions:

```
  create app/adapters/application.js
Installing browser packages via Bower...
  cached git://github.com/firebase/firebase-bower.git#2.1.2
Installed browser packages via Bower.

EmberFire has been installed. Please configure your firebase URL in config/environment.js
```