### PR TITLE
Don't lint inside blueprints when building legacy js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,7 @@ var uglify = require('gulp-uglify');
 var jshint = require('gulp-jshint');
 
 gulp.task('lint', function () {
-  return gulp.src('{addon,app,blueprints,config,tests}/**/*.js')
+  return gulp.src('{addon,app,config,tests}/**/*.js')
     .pipe(jshint())
     .pipe(jshint.reporter('default'));
 });


### PR DESCRIPTION
fixes this:

```
[19:31:20] Using gulpfile ~/build/firebase/emberfire/gulpfile.js
[19:31:20] Starting 'clean-dist'...
[19:31:20] Starting 'lint'...
[19:31:20] Finished 'clean-dist' after 11 ms
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 5, col 16, Expected an identifier and instead saw '<'.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 5, col 17, Expected an operator and instead saw '%='.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 5, col 19, Missing semicolon.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 5, col 31, Expected an identifier and instead saw '>'.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 5, col 32, Expected an operator and instead saw '.'.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 5, col 32, Expected an assignment or function call and instead saw an expression.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 5, col 33, Missing semicolon.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 6, col 26, Expected an identifier and instead saw '<'.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 6, col 27, Expected an operator and instead saw '%='.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 6, col 30, Expected ')' and instead saw 'firebaseUrl'.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 6, col 43, Expected an identifier and instead saw '>'.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 6, col 44, Expected '}' to match '{' from line 5 and instead saw ')'.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 7, col 1, Expected ')' and instead saw '}'.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 7, col 2, Missing semicolon.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 7, col 2, Expected an identifier and instead saw ')'.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 7, col 2, Expected an assignment or function call and instead saw an expression.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 5, col 20, 'baseClass' is not defined.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 5, col 33, 'extend' is not defined.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 1, col 8, 'config' is defined but never used.
/home/travis/build/firebase/emberfire/blueprints/firebase-adapter/files/app/adapters/__name__.js: line 3, col 8, 'FirebaseAdapter' is defined but never used.
20 errors
[19:31:21] Finished 'lint' after 676 ms
[19:31:21] Starting 'build-legacy'...
[19:31:21] Starting 'build-legacy-minified'...
[19:31:22] Finished 'build-legacy-minified' after 1.51 s
[19:31:22] Finished 'build-legacy' after 1.52 s
[19:31:22] Starting 'legacy'...
[19:31:22] Finished 'legacy' after 8.89 μs
```