### PR TITLE
Limit example app blog posts to 20 (reduces load time)

### DIFF
--- a/tests/dummy/app/routes/posts/index.js
+++ b/tests/dummy/app/routes/posts/index.js
@@ -2,6 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model: function() {
-    return this.store.find('post');
+    return this.store.find('post', { limitToLast: 20 });
   }
 });


### PR DESCRIPTION
The blog example was taking forever to load and had a lot of questionable content in it. this limits the blog posts to the last 20.