### PR TITLE
Model specific adapter doesn't need hardcoded prefix

### DIFF
--- a/blueprints/firebase-adapter/index.js
+++ b/blueprints/firebase-adapter/index.js
@@ -1,16 +1,9 @@
-var inflection = require('inflection');
-
 module.exports = {
   description: 'Generates a firebase adapter.',
 
   locals: function(options) {
     var firebaseUrl     = 'config.firebase';
-    var adapterName     = options.entity.name;
     var baseClass       = 'FirebaseAdapter';
-
-    if (adapterName !== 'application') {
-      firebaseUrl = "config.firebase + '/" + inflection.pluralize(adapterName) + "'";
-    }
 
     return {
       baseClass: baseClass,


### PR DESCRIPTION
Model specific adapters were doubling up on the root path. e.g. `ember g firebase-adapter group` would accidentally store data in `https://example.firebaseio.com/groups/groups`.

The firebase adapter already pluralizes the model name for the root path.