### PR TITLE
Support older ember-cli versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 module.exports = {
-  name: 'EmberFire',
+  name: 'emberfire',
 
   included: function included(app) {
     this._super.included(app);

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
   "ember-addon": {
     "configPath": "tests/dummy/config"
   },
+  "peerDependencies": {
+    "ember-cli": ">=0.1.3"
+  },
   "dependencies": {
     "chalk": "^1.0.0",
     "fs-extra": "0.16.4",


### PR DESCRIPTION
Fixes the error, `Path or pattern "EmberFire/**/*.js" did not match any files` which was due to wrong case.

Updated `peerDependencies` to enforce `ember-cli >=0.1.3`, we need this for `Blueprint.prototype.addBowerPackagesToProject`

We could put some more energy in, to allow even older versions, by working around the following:
- 0.1.0 if we stopped using `Blueprint.prototype.insertIntoFile` with the `after` option
- 0.0.43 if we use `Blueprint.prototype.addBowerPackageToProject` instead of the multi version