### PR TITLE
Clear hasMany references if cleared on server

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -296,6 +296,14 @@ export default DS.Adapter.extend(Ember.Evented, {
       }
     } else {
       var payload = this._assignIdToPayload(snapshot);
+
+      // firebase doesn't send the property for empty relationships
+      type.eachRelationship(function (key, relationship) {
+        if (relationship.kind === 'hasMany' && !payload[key]) {
+          payload[key] = {};
+        }
+      });
+
       this._enqueue(function() {
         store.push(type, serializer.extractSingle(store, type, payload));
       });

--- a/tests/integration/updates-from-server-test.js
+++ b/tests/integration/updates-from-server-test.js
@@ -302,6 +302,39 @@ describe("Integration: FirebaseAdapter - Updates from server", function() {
     });
   });
 
+describe("belongsTo relationships", function() {
+    var _ref, currentComment, reference;
+
+    beforeEach(function(done) {
+      setupAdapter();
+      _ref = adapter._ref;
+      reference = firebaseTestRef.child("blogs/normalized");
+      adapter._ref = reference;
+      Ember.run(function() {
+        store.find("comment", 'comment_1').then(function(comment) {
+          currentComment = comment;
+          done();
+        });
+      });
+    });
+
+
+    it("removes the client side association when removed on server", function(done) {
+      assert(currentComment.get('user.id'), 'should have a user');
+      Ember.run(function () {
+        reference.child('comments/comment_1/user').remove(function() {
+          assert(currentComment.get('user'), 'user association should be missing');
+          done();
+        });
+      });
+    });
+
+    after(function(done) {
+      adapter._ref = _ref;
+      done();
+    });
+  });
+
   describe("Deleting a record clientside, deletes it on the server side as well", function() {
     var _ref, reference;
 


### PR DESCRIPTION
When a hasMany array is removed on the server the property is not sent in the snapshot payload, this causes `ember-data` to believe there are "no changes" to the relationships rather than clearing them.

This PR forces the adapter to clear the relationships.