### PR TITLE
Test against multiple versions of ember-data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,16 @@ install:
   - npm install -g bower
   - npm install
   - bower install
+  - ./config/select-dep-versions.js
 
 script:
   - npm run legacy
   - npm test
+
+env:
+  matrix:
+    - EMBER_DATA_VERSION=1.0.0-beta.12
+    - EMBER_DATA_VERSION=1.0.0-beta.14.1
+    - EMBER_DATA_VERSION=1.0.0-beta.15
+    - EMBER_DATA_VERSION=1.0.0-beta.16
+    - EMBER_DATA_VERSION=canary

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ env:
     - EMBER_DATA_VERSION=1.0.0-beta.12
     - EMBER_DATA_VERSION=1.0.0-beta.14.1
     - EMBER_DATA_VERSION=1.0.0-beta.15
-    - EMBER_DATA_VERSION=1.0.0-beta.16
-    - EMBER_DATA_VERSION=canary
+    # - EMBER_DATA_VERSION=1.0.0-beta.16
+    # - EMBER_DATA_VERSION=canary

--- a/README.md
+++ b/README.md
@@ -51,16 +51,40 @@ If you'd like to contribute to EmberFire, run the following commands to get your
 * `npm install`
 * `bower install`
 
-### Running
+### Using a local EmberFire workdir in another project
 
-* `ember server`
-* Visit your app at http://localhost:4200.
+From your `emberfire` workdir
+
+* `npm link`
+* `rm -rf node_modules`
+* `npm install --production` (does not install dev dependencies, these can trip you up!)
+
+From your *app* workdir
+
+* `npm link emberfire`
+* Update your `package.json` so that `emberfire` is in `devDependencies` and is set to version `0.0.0`
+
+  ```
+  "devDependencies": {
+    "emberfire": "0.0.0"
+  ``` 
 
 ### Running Tests
 
 * `ember test`
 * `ember test --server`
 
-### Building
+##### Running tests against a specific version of ember-data
 
-* `ember build`
+Invoke `./config/select-dep-versions.js` with environment var `EMBER_DATA_VERSION=<version>` where `<version>` is an `ember-data` version number (e.g. `1.0.0-beta.12`) or `beta` or `canary`.
+
+Example:
+
+```
+EMBER_DATA_VERSION=canary ./config/select-dep-versions.js && ember test
+```
+
+### Running the FireBlog demo app
+
+* `ember server`
+* Visit your app at http://localhost:4200.

--- a/config/select-dep-versions.js
+++ b/config/select-dep-versions.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+/* adapted from ef4/liquid-fire */
+
+var fs = require('fs');
+var path = require('path');
+var RSVP = require('rsvp');
+var spawn = require('child_process').spawn;
+
+function maybeChangeVersion(channel) {
+  if (typeof(channel) === 'undefined') {
+    return RSVP.Promise.resolve('existing');
+  }
+  var bowerFile = path.join(__dirname, '..', 'bower.json');
+
+  return run('git', ['checkout', bowerFile])
+    .then(function() {
+      var bowerJSON = require(bowerFile);
+      fs.writeFileSync(bowerFile, JSON.stringify(rewrite(bowerJSON, channel), null, 2));
+
+      return run('bower', ['install'], {cwd: path.join(__dirname, '..')});
+
+    })
+    .then(function () {
+      return run('git', ['checkout', 'package.json'], {cwd: path.join(__dirname, '..')});
+    })
+    .then(function () {
+      if (channel === 'canary' || channel === 'beta' ) {
+        return run('npm', ['install'], {cwd: path.join(__dirname, '..')});
+      }
+      return run('npm', ['install', '--save-dev', 'ember-data@' + channel], {cwd: path.join(__dirname, '..')});
+    })
+    .then(function() {
+      return channel;
+    });
+}
+
+function run(command, args, opts) {
+  return new RSVP.Promise(function(resolve, reject) {
+    var p = spawn(command, args, opts || {});
+    var stderr = '';
+    p.stderr.on('data', function(output) {
+      stderr += output;
+    });
+    p.on('close', function(code){
+      if (code !== 0) {
+        console.log(stderr);
+        reject(command + " exited with nonzero status");
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+function rewrite(bowerJSON, channel) {
+  if (channel === 'existing') {
+    return bowerJSON;
+  }
+
+  if (!bowerJSON.resolutions) {
+    bowerJSON.resolutions = {};
+  }
+
+  if (bowerJSON.dependencies['ember-data']) {
+    delete bowerJSON.dependencies['ember-data'];
+  }
+
+  bowerJSON.devDependencies['ember-data'] = "components/ember-data#" + channel;
+  bowerJSON.resolutions['ember-data'] = channel;
+
+  return bowerJSON;
+}
+
+function foundVersion(package) {
+  var filename = path.join(__dirname, '..', 'bower_components', package, 'bower.json');
+  if (fs.existsSync(filename)) {
+    return require(filename).version;
+  }
+  filename = path.join(__dirname, '..', 'node_modules', package, 'package.json');
+  if (fs.existsSync(filename)) {
+    return require(filename).version;
+  }
+  return "none";
+}
+
+function logVersions(channel) {
+  console.log("Based on " + channel + " I'm using:");
+  var module = 'ember-data';
+  console.log("  " + module + " " + foundVersion(module));
+}
+
+maybeChangeVersion(process.env.EMBER_DATA_VERSION).then(function(channel){
+  logVersions(channel);
+  process.exit(0);
+}).catch(function(err){
+  console.log(err);
+  console.log(err.stack);
+  process.exit(-1);
+});

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "gulp-header": "1.2.2",
     "gulp-jshint": "1.9.2",
     "gulp-sourcemaps": "1.5.0",
-    "gulp-uglify": "1.1.0"
+    "gulp-uglify": "1.1.0",
+    "rsvp": "^3.0.17"
   }
 }


### PR DESCRIPTION
Test against multiple versions of `ember-data`. Will make it very easy for us to test against canary.

Locally, run: 

```
$ EMBER_DATA_VERSION=1.0.0-beta.16 node ./config/select-dep-versions.js && ember test
Based on 1.0.0-beta.16 I'm using:
  ember-data 1.0.0-beta.16
```

```
$ EMBER_DATA_VERSION=canary node ./config/select-dep-versions.js && ember test
Based on canary I'm using:
  ember-data 1.0.0-beta.17+canary.e8ceeeb4c0
```

**Note:** I'm expecting this to fail for `canary` and `beta.16`

- [x] Remove failing ED versions (for now)
- [x] Add documentation to `README.md` on how to select a version locally

/cc @brendanoh