### PR TITLE
Update installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ to ask technical questions, share apps you've built, and chat with other develop
 To install EmberFire as an addon with your Ember CLI app, run the following command within your app's directory:
 
 ```bash
-$ ember install:addon emberfire
+$ ember install emberfire
 ```
 
 This will add Firebase as a dependency in your `bower.json` file, create `app/adapters/application.js` and add configuration to `config/environment.js`. Now, update your firebase url in `config/environment.js`:


### PR DESCRIPTION
The command to install addons has changed to `$ ember install` since Ember CLI v0.2.3.

View the [changelog for v0.2.3](https://github.com/ember-cli/ember-cli/blob/master/CHANGELOG.md#023) or the [PR](https://github.com/ember-cli/ember-cli/pull/3598).