### PR TITLE
Monkey patch store before it is initialized

### DIFF
--- a/addon/initializers/emberfire.js
+++ b/addon/initializers/emberfire.js
@@ -16,7 +16,7 @@ if (Ember.libraries) {
 
 export default {
   name: 'emberfire',
-  before: 'store',
+  before: 'ember-data',
   initialize: function (container, app) {
     app.register('adapter:-firebase', FirebaseAdapter);
     app.register('serializer:-firebase', FirebaseSerializer);


### PR DESCRIPTION
Fixes #213 (again)

It seems `store` initializer is actually a noop, set to run after `ember-data` [here](https://github.com/emberjs/data/blob/v1.0.0-beta.12/packages/ember-data/lib/ember-initializer.js#L43-L54).

Specifying to run *before* `store` means that it **might** run before `ember-data`, but with no guarantee. This seemed to only affect us when using the prebuilt bower/CDN `emberfire` due to some race condition.

We actually want to run before `ember-data` initializer. Here `DS` is available in the global scope but `store:main` has definitely not been initialized.

#216