### PR TITLE
Restore latest ember-data (npm) when testing canary

### DIFF
--- a/config/select-dep-versions.js
+++ b/config/select-dep-versions.js
@@ -25,10 +25,11 @@ function maybeChangeVersion(channel) {
       return run('git', ['checkout', 'package.json'], {cwd: path.join(__dirname, '..')});
     })
     .then(function () {
+      var npmVersion = channel;
       if (channel === 'canary' || channel === 'beta' ) {
-        return run('npm', ['install'], {cwd: path.join(__dirname, '..')});
+        npmVersion = 'latest';
       }
-      return run('npm', ['install', '--save-dev', 'ember-data@' + channel], {cwd: path.join(__dirname, '..')});
+      return run('npm', ['install', '--save-dev', 'ember-data@' + npmVersion], {cwd: path.join(__dirname, '..')});
     })
     .then(function() {
       return channel;


### PR DESCRIPTION
Was causing an issue where canary tests had an incorrect npm dependency for ember-data. this forces it to use `npm@latest` when testing canary