### PR TITLE
Embedded record updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,5 @@ env:
     - EMBER_DATA_VERSION=1.0.0-beta.17
     - EMBER_DATA_VERSION=1.0.0-beta.18
     - EMBER_DATA_VERSION=canary
+    allow_failures:
+      - EMBER_DATA_VERSION=canary

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,16 @@ script:
   - npm run legacy
   - npm test
 
-env:
-  matrix:
-    - EMBER_DATA_VERSION=1.0.0-beta.12
-    - EMBER_DATA_VERSION=1.0.0-beta.14.1
-    - EMBER_DATA_VERSION=1.0.0-beta.15
-    # - EMBER_DATA_VERSION=1.0.0-beta.16 # broken adapterFor('application')
-    - EMBER_DATA_VERSION=1.0.0-beta.16.1
-    - EMBER_DATA_VERSION=1.0.0-beta.17
-    - EMBER_DATA_VERSION=1.0.0-beta.18
-    - EMBER_DATA_VERSION=canary
-    allow_failures:
-      - EMBER_DATA_VERSION=canary
+matrix:
+  include:
+    - env: EMBER_DATA_VERSION=1.0.0-beta.12
+    - env: EMBER_DATA_VERSION=1.0.0-beta.14.1
+    - env: EMBER_DATA_VERSION=1.0.0-beta.15
+    # - env: EMBER_DATA_VERSION=1.0.0-beta.16 # broken adapterFor('application')
+    - env: EMBER_DATA_VERSION=1.0.0-beta.16.1
+    - env: EMBER_DATA_VERSION=1.0.0-beta.17
+    - env: EMBER_DATA_VERSION=1.0.0-beta.18
+    - env: EMBER_DATA_VERSION=canary
+
+  allow_failures:
+    - env: EMBER_DATA_VERSION=canary

--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -460,7 +460,12 @@ export default DS.Adapter.extend(Ember.Evented, {
     var isEmbedded = relationship.options.embedded === true;
     if (isEmbedded) {
       record.__firebaseRef = ref;
-      return this.updateRecord(store, relationship.type, record);
+      record.send('willCommit');
+      return this.updateRecord(store, relationship.type, record, 'hasMany')
+        .then(function () {
+          record.set('_attributes', {});
+          record.adapterDidCommit();
+        });
     }
 
     return toPromise(ref.set, ref,  [true]);
@@ -480,7 +485,12 @@ export default DS.Adapter.extend(Ember.Evented, {
   _saveBelongsToRecord: function(store, type, relationship, id, parentRef) {
     var record = store.getById(relationship.type, id);
     record.__firebaseRef = parentRef.child(relationship.key);
-    return this.updateRecord(store, relationship.type, record, 'belongsTo');
+    record.send('willCommit');
+    return this.updateRecord(store, relationship.type, record, 'belongsTo')
+      .then(function () {
+        record.set('_attributes', {});
+        record.adapterDidCommit();
+      });
   },
 
   /**

--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -337,10 +337,10 @@ export default DS.Adapter.extend(Ember.Evented, {
     for saving nested records as well.
 
   */
-  updateRecord: function(store, type, snapshot, _recordRef) {
+  updateRecord: function(store, type, snapshot) {
     var adapter = this;
     var record = snapshot.record || snapshot;
-    var recordRef = _recordRef || this._getRef(type, record.get('id'));
+    var recordRef = record.__firebaseRef || this._getRef(type, record.get('id'));
     var modelName = Ember.String.camelize(type.modelName || type.typeKey);
     var recordCache = adapter._getRecordCache(modelName, record.get('id'));
 
@@ -457,7 +457,8 @@ export default DS.Adapter.extend(Ember.Evented, {
     var record = store.getById(relationship.type, id);
     var isEmbedded = relationship.options.embedded === true;
     if (isEmbedded) {
-      return this.updateRecord(store, relationship.type, record, ref);
+      record.__firebaseRef = ref;
+      return this.updateRecord(store, relationship.type, record);
     }
 
     return toPromise(ref.set, ref,  [true]);
@@ -475,9 +476,9 @@ export default DS.Adapter.extend(Ember.Evented, {
     Save an embedded record
   */
   _saveBelongsToRecord: function(store, type, relationship, id, parentRef) {
-    var ref = parentRef.child(relationship.key);
     var record = store.getById(relationship.type, id);
-    return this.updateRecord(store, relationship.type, record, ref);
+    record.__firebaseRef = parentRef.child(relationship.key);
+    return this.updateRecord(store, relationship.type, record);
   },
 
   /**

--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -337,14 +337,16 @@ export default DS.Adapter.extend(Ember.Evented, {
     for saving nested records as well.
 
   */
-  updateRecord: function(store, type, snapshot) {
+  updateRecord: function(store, type, snapshot, embeddedType) {
     var adapter = this;
     var record = snapshot.record || snapshot;
     var recordRef = record.__firebaseRef || this._getRef(type, record.get('id'));
     var modelName = Ember.String.camelize(type.modelName || type.typeKey);
     var recordCache = adapter._getRecordCache(modelName, record.get('id'));
 
-    var serializedRecord = record.serialize({includeId:false});
+    var serializedRecord = record.serialize({
+      includeId: embeddedType === 'belongsTo'
+    });
 
     return new Promise(function(resolve, reject) {
       var savedRelationships = Ember.A();
@@ -478,7 +480,7 @@ export default DS.Adapter.extend(Ember.Evented, {
   _saveBelongsToRecord: function(store, type, relationship, id, parentRef) {
     var record = store.getById(relationship.type, id);
     record.__firebaseRef = parentRef.child(relationship.key);
-    return this.updateRecord(store, relationship.type, record);
+    return this.updateRecord(store, relationship.type, record, 'belongsTo');
   },
 
   /**

--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -346,9 +346,8 @@ export default DS.Adapter.extend(Ember.Evented, {
 
     var pathPieces = recordRef.path.toString().split('/');
     var lastPiece = pathPieces[pathPieces.length-1];
-    var includeId = (lastPiece !== record.id); // record has no key
     var serializedRecord = record.serialize({
-      includeId
+      includeId: (lastPiece !== record.id) // record has no firebase `key` in path
     });
 
     return new Promise(function(resolve, reject) {

--- a/addon/initializers/emberfire.js
+++ b/addon/initializers/emberfire.js
@@ -60,6 +60,17 @@ export default {
         deleteRecord: function () {
           this.store.recordWillDelete(this);
           this._super();
+        },
+
+        ref: function () {
+          if (this.__firebaseRef) {
+            return this.__firebaseRef;
+          }
+
+          var adapter = this.store.adapterFor(this.constructor);
+          if (adapter._getRef) {
+            return adapter._getRef(this.constructor, this.id);
+          }
         }
       });
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,18 +2,13 @@
 var gulp = require('gulp');
 
 var del = require('del');
-var sourcemaps = require('gulp-sourcemaps');
-var transpile  = require('gulp-es6-module-transpiler');
-var concat = require('gulp-concat');
-var uglify = require('gulp-uglify');
-var jshint = require('gulp-jshint');
-var header = require('gulp-header');
+var $ = require('gulp-load-plugins')();
 var fs = require('fs');
 
 gulp.task('lint', function () {
   return gulp.src('{addon,app,config,tests}/**/*.js')
-    .pipe(jshint())
-    .pipe(jshint.reporter('default'));
+    .pipe($.jshint())
+    .pipe($.jshint.reporter('default'));
 });
 
 gulp.task('clean-dist', function (cb) {
@@ -25,28 +20,29 @@ gulp.task('clean-dist', function (cb) {
 
 gulp.task('build-legacy', ['lint'], function() {
   return gulp.src('vendor/legacy-shims/emberfire.js')
-    .pipe(sourcemaps.init())
-    .pipe(transpile({
+    .pipe($.sourcemaps.init())
+    .pipe($.es6ModuleTranspiler({
       importPaths: ['vendor/legacy-shims'],
       formatter: 'bundle'
     }))
-    .pipe(concat('emberfire.js'))
-    .pipe(header(fs.readFileSync('vendor/legacy-shims/header.js', 'utf8')))
-    .pipe(sourcemaps.write('./'))
+    .pipe($.concat('emberfire.js'))
+    .pipe($.header(fs.readFileSync('vendor/legacy-shims/header.js', 'utf8')))
+    .pipe($.sourcemaps.write('./'))
     .pipe(gulp.dest('dist'));
 });
 
 gulp.task('build-legacy-minified', ['lint'], function() {
   return gulp.src('vendor/legacy-shims/emberfire.js')
-    .pipe(transpile({
+    .pipe($.es6ModuleTranspiler({
       importPaths: ['vendor/legacy-shims'], // for 'ember' and 'ember-data' global shims
       formatter: 'bundle'
     }))
-    .pipe(concat('emberfire.min.js'))
-    .pipe(header(fs.readFileSync('vendor/legacy-shims/header.js', 'utf8')))
-    .pipe(uglify({
-      preserveComments: 'some'
-    }))
+    .pipe($.concat('emberfire.min.js'))
+    .pipe($.uglify())
+    .on('error', function (e) {
+      throw new $.util.PluginError('gulp-uglify', e.message);
+    })
+    .pipe($.header(fs.readFileSync('vendor/legacy-shims/header.js', 'utf8')))
     .pipe(gulp.dest('dist'));
 });
 

--- a/package.json
+++ b/package.json
@@ -62,8 +62,9 @@
     "gulp-es6-module-transpiler": "0.2.1",
     "gulp-header": "1.2.2",
     "gulp-jshint": "1.9.2",
+    "gulp-load-plugins": "0.10.0",
     "gulp-sourcemaps": "1.5.0",
     "gulp-uglify": "1.1.0",
-    "rsvp": "^3.0.17"
+    "gulp-util": "3.0.4"
   }
 }

--- a/tests/integration/deleting-records-test.js
+++ b/tests/integration/deleting-records-test.js
@@ -1,11 +1,12 @@
 import Ember from 'ember';
+import DS from 'ember-data';
 import startApp from 'dummy/tests/helpers/start-app';
 import { it } from 'ember-mocha';
 import stubFirebase from 'dummy/tests/helpers/stub-firebase';
 import unstubFirebase from 'dummy/tests/helpers/unstub-firebase';
 import createTestRef from 'dummy/tests/helpers/create-test-ref';
 
-describe("Integration: FirebaseAdapter - Deleting records", function() {
+describe('Integration: FirebaseAdapter - Deleting records', function() {
   var app, store, adapter, firebaseTestRef;
 
   beforeEach(function () {
@@ -13,7 +14,7 @@ describe("Integration: FirebaseAdapter - Deleting records", function() {
     app = startApp();
 
     firebaseTestRef = createTestRef();
-    store = app.__container__.lookup("store:main");
+    store = app.__container__.lookup('store:main');
     adapter = store.adapterFor('application');
   });
 
@@ -22,24 +23,178 @@ describe("Integration: FirebaseAdapter - Deleting records", function() {
     Ember.run(app, 'destroy');
   });
 
-  describe("when a belongsTo relationship exists", function() {
+  describe('when a record is created, then deleted locally', function() {
+    var _ref, newPost, postId, postRef;
+
+    beforeEach(function(done) {
+      _ref = adapter._ref;
+      var reference = firebaseTestRef.child('blogs/tests/adapter/deleterecord/normalized');
+      adapter._ref = reference;
+      Ember.run(function() {
+        newPost = store.createRecord('post', {
+          title: 'New Post'
+        });
+        postId = newPost.get('id');
+        postRef = newPost.ref();
+        newPost.save().then(function() {
+          done();
+        });
+      });
+    });
+
+    it('removes the record from the server', function(done) {
+      newPost.destroyRecord().then(function () {
+        postRef.once('value', function(snapshot) {
+          assert.equal(snapshot.val(), null);
+          done();
+        });
+      });
+    });
+
+  });
+
+  describe('when a record is retrieved through `find` and then deleted', function() {
+    var _ref, post, postId, postRef;
+
+    beforeEach(function(done) {
+      _ref = adapter._ref;
+      var reference = firebaseTestRef.child('blogs/normalized');
+      adapter._ref = reference;
+      Ember.run(function() {
+        store.find('post', 'post_1').then(function(p) {
+          post = p;
+          postId = post.get('id');
+          postRef = post.ref();
+          done();
+        });
+      });
+    });
+
+    it('removes the record from the server', function(done) {
+      post.destroyRecord().then(function () {
+        postRef.once('value', function(snapshot) {
+          assert.equal(snapshot.val(), null);
+          done();
+        });
+      });
+    });
+
+  });
+
+  describe('an embedded (hasMany) record coming from the server', function() {
+    var comment, reference;
+
+    beforeEach(function(done) {
+      // needs a better way that uses the container
+      app.Post = DS.Model.extend({
+        title: DS.attr('string'),
+        body: DS.attr('string'),
+        published: DS.attr('number'),
+        publishedDate: Ember.computed('published', function() {
+          return this.get('published');
+        }),
+        user: DS.belongsTo('user', { async: true }),
+        comments: DS.hasMany('comment', { async: true }),
+        embeddedComments: DS.hasMany('comment', { embedded: true })
+      });
+
+      reference = firebaseTestRef.child('blogs/double_denormalized');
+      adapter._ref = reference;
+      Ember.run(function() {
+        store.find('post', 'post_1').then(function(post) {
+          comment = post.get('embeddedComments').objectAt(0);
+          done();
+        });
+      });
+    });
+
+    afterEach(() => {
+      delete app.Post;
+    });
+
+    it('removes the record from the server', function(done) {
+      var commentRef = reference.child('posts/post_1/embeddedComments/comment_1');
+      comment.destroyRecord().then(function () {
+        commentRef.once('value', function(snapshot) {
+          assert.equal(snapshot.val(), null);
+          done();
+        });
+      });
+    });
+
+  });
+
+  describe('an embedded (belongsTo) record inside another embedded record', function() {
+    var user, reference;
+
+    beforeEach(function(done) {
+      app.Post = DS.Model.extend({
+        title: DS.attr('string'),
+        body: DS.attr('string'),
+        published: DS.attr('number'),
+        publishedDate: Ember.computed('published', function() {
+          return this.get('published');
+        }),
+        user: DS.belongsTo('user', { async: true }),
+        comments: DS.hasMany('comment', { async: true }),
+        embeddedComments: DS.hasMany('comment', { embedded: true })
+      });
+
+      app.Comment = DS.Model.extend({
+        body: DS.attr('string'),
+        published: DS.attr('number'),
+        publishedDate: Ember.computed('published', function() {
+          return this.get('published');
+        }),
+        user: DS.belongsTo('user', { async: true }),
+        embeddedUser: DS.belongsTo('user', { embedded: true, inverse:null })
+      });
+
+      reference = firebaseTestRef.child('blogs/double_denormalized');
+      adapter._ref = reference;
+      Ember.run(function() {
+        store.find('post', 'post_1').then(function(post) {
+          user = post.get('embeddedComments').objectAt(0).get('embeddedUser');
+          done();
+        });
+      });
+    });
+
+    afterEach(() => {
+      delete app.Post;
+      delete app.Comment;
+    });
+
+    it('removes the record from the server', function(done) {
+      var userRef = reference.child('posts/post_1/embeddedComments/comment_1/embeddedUser');
+      user.destroyRecord().then(function () {
+        userRef.once('value', function(snapshot) {
+          assert.equal(snapshot.val(), null);
+          done();
+        });
+      });
+    });
+
+  });
+
+  describe('when a belongsTo relationship exists', function() {
     var _ref, newPost, newUser, postId, userRef, userId;
 
     beforeEach(function(done) {
       _ref = adapter._ref;
-      var reference = firebaseTestRef.child("blogs/tests/adapter/deleterecord/normalized");
+      var reference = firebaseTestRef.child('blogs/tests/adapter/deleterecord/normalized');
       adapter._ref = reference;
       Ember.run(function() {
-        newUser = store.createRecord("user", {
-          firstName: "Tom"
+        newUser = store.createRecord('user', {
+          firstName: 'Tom'
         });
-        newPost = store.createRecord("post", {
-          title: "New Post"
+        newPost = store.createRecord('post', {
+          title: 'New Post'
         });
         postId = newPost.get('id');
         userId = newUser.get('id');
-        userRef = reference.child("users/" + userId);
-        Ember.RSVP.Promise.cast(newUser.get("posts")).then(function(posts) {
+        userRef = reference.child('users/' + userId);
+        Ember.RSVP.Promise.cast(newUser.get('posts')).then(function(posts) {
           posts.pushObject(newPost);
           newUser.save().then(function() {
             done();
@@ -48,7 +203,7 @@ describe("Integration: FirebaseAdapter - Deleting records", function() {
       });
     });
 
-    it("removes entries from inverse (hasMany) side", function(done) {
+    it('removes entries from inverse (hasMany) side', function(done) {
       newPost.destroyRecord().then(function () {
         userRef.once('value', function(snapshot) {
           var userData = snapshot.val();

--- a/tests/integration/updates-from-server-test.js
+++ b/tests/integration/updates-from-server-test.js
@@ -111,7 +111,7 @@ describe("Integration: FirebaseAdapter - Updates from server", function() {
     });
   });
 
-  describe("An embedded record coming from the server", function() {
+  describe("An embedded (hasMany) record coming from the server", function() {
     var comment, reference;
 
     beforeEach(function(done) {
@@ -144,7 +144,7 @@ describe("Integration: FirebaseAdapter - Updates from server", function() {
 
   });
 
-  describe("An embedded record inside another embedded record", function() {
+  describe("An embedded (belongsTo) record inside another embedded record", function() {
     var user, reference;
 
     beforeEach(function(done) {

--- a/tests/integration/updating-records-test.js
+++ b/tests/integration/updating-records-test.js
@@ -314,7 +314,7 @@ describe("Integration: FirebaseAdapter - Updating records", function() {
 
     describe("embedded hasMany records", function() {
 
-      var newPost, newComment, currentData, postData, commentData;
+      var reference, newPost, newComment, currentData, postData, commentData;
       var postId, commentId;
 
       beforeEach(function(done) {
@@ -329,7 +329,7 @@ describe("Integration: FirebaseAdapter - Updating records", function() {
           comments: DS.hasMany("comment", { embedded: true }) // force embedded
         });
 
-        var reference = firebaseTestRef.child("denormalized");
+        reference = firebaseTestRef.child("denormalized");
         adapter._ref = reference;
         Ember.run(function() {
           newComment = store.createRecord("comment", {
@@ -409,11 +409,38 @@ describe("Integration: FirebaseAdapter - Updating records", function() {
         assert.equal(newComment.get('body'), 'This is a new comment');
       });
 
-    });
+      describe('when invoking .save() directly', function () {
+
+        it("update on the server at the correct location", function(done) {
+          Ember.run(() => {
+            newComment.set('body', 'Updated');
+            newComment.save().then(() => {
+              newComment.ref().once('value', function (snap) {
+                assert.equal(snap.val().body, "Updated");
+                done();
+              });
+            });
+          });
+        });
+
+        it("do not duplicate data on the server", function(done) {
+          Ember.run(() => {
+            newComment.save().then(() => {
+              reference.once('value', function (snap) {
+                assert.equal(snap.val().comments, undefined);
+                done();
+              });
+            });
+          });
+        });
+
+      }); // when invoking .save() directly
+
+    }); // embedded hasMany records
 
     describe("embedded belongsTo records", function() {
 
-      var newPost, newComment, currentData, postData, commentData;
+      var reference, newPost, newComment, currentData, postData, commentData;
       var postId, commentId;
 
       beforeEach(function(done) {
@@ -428,7 +455,7 @@ describe("Integration: FirebaseAdapter - Updating records", function() {
           comment: DS.belongsTo("comment", { embedded: true }) // force embedded
         });
 
-        var reference = firebaseTestRef.child("denormalized");
+        reference = firebaseTestRef.child("denormalized");
         adapter._ref = reference;
         Ember.run(function() {
           newComment = store.createRecord("comment", {
@@ -512,7 +539,34 @@ describe("Integration: FirebaseAdapter - Updating records", function() {
         assert.equal(newComment.get('body'), 'This is a new comment');
       });
 
-    });
+      describe('when invoking .save() directly', function () {
+
+        it("update on the server at the correct location", function(done) {
+          Ember.run(() => {
+            newComment.set('body', 'Updated');
+            newComment.save().then(() => {
+              newComment.ref().once('value', function (snap) {
+                assert.equal(snap.val().body, "Updated");
+                done();
+              });
+            });
+          });
+        });
+
+        it("do not duplicate data on the server", function(done) {
+          Ember.run(() => {
+            newComment.save().then(() => {
+              reference.once('value', function (snap) {
+                assert.equal(snap.val().comments, undefined);
+                done();
+              });
+            });
+          });
+        });
+
+      }); // when invoking .save() directly
+
+    }); // embedded belongsTo records
 
   });
 

--- a/tests/integration/updating-records-test.js
+++ b/tests/integration/updating-records-test.js
@@ -395,6 +395,20 @@ describe("Integration: FirebaseAdapter - Updating records", function() {
         });
       });
 
+      it("rollback to a clean state", function() {
+        newComment.set('body', 'new body');
+        assert(newComment.get('isDirty'), "The embedded record should be 'dirty'");
+        newComment.rollback();
+        assert(!newComment.get('isDirty'), "The embedded record should not be 'dirty'");
+      });
+
+      it("rollback to their last saved state", function() {
+        newComment.set('body', 'new body');
+        assert(newComment.get('isDirty'), "The embedded record should be 'dirty'");
+        newComment.rollback();
+        assert.equal(newComment.get('body'), 'This is a new comment');
+      });
+
     });
 
     describe("embedded belongsTo records", function() {
@@ -482,6 +496,20 @@ describe("Integration: FirebaseAdapter - Updating records", function() {
             done();
           });
         });
+      });
+
+      it("rollback to a clean state", function() {
+        newComment.set('body', 'new body');
+        assert(newComment.get('isDirty'), "The embedded record should be 'dirty'");
+        newComment.rollback();
+        assert(!newComment.get('isDirty'), "The embedded record should not be 'dirty'");
+      });
+
+      it("rollback to their last saved state", function() {
+        newComment.set('body', 'new body');
+        assert(newComment.get('isDirty'), "The embedded record should be 'dirty'");
+        newComment.rollback();
+        assert.equal(newComment.get('body'), 'This is a new comment');
       });
 
     });


### PR DESCRIPTION
- Exposed `record.ref()` to get the firebase ref to a particular record. #239 #173 - Great for `onDisconnect` operations:

  ```js
  currentUser.set('status', 'online');
  currentUser.save();
  currentUser.ref().child('status').onDisconnect().set('offline')
  ```

- Embedded records when saved by themselves no longer write data at the root collection level in Firebase. #135 #220 
- Embedded `belongsTo` records now serialize an id #200 #247 
- Embedded records clear their `isDirty` and `isNew` state when saving the parent. #154 #95
- Embedded records can now invoke `.destroyRecord()` directly and their data will correctly be removed on the server

Before merge:
- [x] tests for rollback of embedded records
- [x] tests for `model.ref()`
- [x] documentation for  `model.ref()`
- [x] set `model._firebaseRef` when loading embedded records