### PR TITLE
Merge torii fire

### DIFF
--- a/addon/services/firebase.js
+++ b/addon/services/firebase.js
@@ -1,0 +1,10 @@
+import Firebase from 'firebase';
+
+export default {
+  create() {
+    return new Firebase(this.config.firebase);
+  },
+
+  config: null,
+  isServiceFactory: true
+};

--- a/addon/torii-providers/firebase.js
+++ b/addon/torii-providers/firebase.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+
+export default Ember.Object.extend({
+  firebase: Ember.inject.service(),
+
+  open: function(options) {
+    var self = this;
+
+    return new Ember.RSVP.Promise(function(resolve, reject) {
+      self.get('firebase').authWithOAuthPopup(options.authWith, function(error, authData) {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(authData);
+        }
+      });
+    });
+  }
+});

--- a/app/services/firebase.js
+++ b/app/services/firebase.js
@@ -1,0 +1,6 @@
+import Firebase from 'emberfire/services/firebase';
+import config from '../config/environment';
+
+Firebase.config = config;
+
+export default Firebase;

--- a/app/torii-providers/firebase.js
+++ b/app/torii-providers/firebase.js
@@ -1,0 +1,3 @@
+import FirebaseProvider from 'emberfire/torii-providers/firebase';
+
+export default FirebaseProvider;

--- a/blueprints/emberfire/files/app/adapters/application.js
+++ b/blueprints/emberfire/files/app/adapters/application.js
@@ -1,7 +1,8 @@
-import config from '../config/environment';
-import Firebase from 'firebase';
+import Ember from 'ember';
 import FirebaseAdapter from 'emberfire/adapters/firebase';
 
+const {inject, computed} = Ember;
+
 export default FirebaseAdapter.extend({
-  firebase: new Firebase(config.firebase)
+  firebase: inject.service(),
 });

--- a/bower.json
+++ b/bower.json
@@ -47,5 +47,10 @@
     "normalize-css": "2.1.3",
     "sinon": "http://sinonjs.org/releases/sinon-1.15.0.js",
     "mockfirebase": "0.11.0"
+  },
+  "resolutions": {
+    "mocha": "~2.2.4",
+    "chai": "~2.3.0",
+    "ember-mocha-adapter": "~0.3.1"
   }
 }

--- a/tests/dummy/app/adapters/application.js
+++ b/tests/dummy/app/adapters/application.js
@@ -1,7 +1,8 @@
-import config from '../config/environment';
-import Firebase from 'firebase';
+import Ember from 'ember';
 import FirebaseAdapter from 'emberfire/adapters/firebase';
 
+const { inject } = Ember;
+
 export default FirebaseAdapter.extend({
-  firebase: new Firebase(config.firebase)
+  firebase: inject.service(),
 });

--- a/tests/unit/services/firebase-test.js
+++ b/tests/unit/services/firebase-test.js
@@ -1,0 +1,19 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import {
+  describeModule,
+  it
+} from 'ember-mocha';
+import Firebase from 'firebase';
+
+describeModule(
+  'service:firebase',
+  'FirebaseService',
+  { },
+  function() {
+    it('exists', function() {
+      const service = this.subject();
+      expect(service instanceof Firebase);
+    });
+  }
+);

--- a/tests/unit/torii-providers/firebase-test.js
+++ b/tests/unit/torii-providers/firebase-test.js
@@ -1,0 +1,44 @@
+import Ember from 'ember';
+import { describeModule, it } from 'ember-mocha';
+import sinon from 'sinon';
+
+describeModule('torii-provider:firebase', 'FirebaseProvider', {
+  needs: ['service:firebase'],
+}, function() {
+
+  describe('#open', function() {
+    it('errors when firebase.authWithOAuthPopup errors', function() {
+      let provider = this.subject();
+      let errorMock = sinon.spy();
+      const firebaseMock = {
+        authWithOAuthPopup: sinon.stub().yields(errorMock)
+      };
+      provider.set('firebase', firebaseMock);
+
+      Ember.run(function() {
+        provider.open({authWith: 'errorProvider'}).catch(function(error) {
+          assert.ok(firebaseMock.authWithOAuthPopup.calledWith('errorProvider'));
+
+          assert.equal(error, errorMock);
+        });
+      });
+    });
+
+    it('returns authData when firebase.authWithOAuthPopup returns authData', function() {
+      let provider = this.subject();
+      let authDataMock = sinon.spy();
+      const firebaseMock = {
+        authWithOAuthPopup: sinon.stub().yields(null, authDataMock)
+      };
+      provider.set('firebase', firebaseMock);
+
+      Ember.run(function() {
+        provider.open({authWith: 'successProvider'}).then(function(authData) {
+          assert.ok(firebaseMock.authWithOAuthPopup.calledWith('successProvider'));
+
+          assert.equal(authData, authDataMock);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This has two commits. The first extracts the Firbase instace into a service.

Why:

* We'd like to use the firebase instance in multiple places, rather then
importing the application adapter, it would be better to have a service
that provides this.

This Commit:

* Creates a firebased service that provides a global instance of
Firebase.

The second Add a torii adapter for firebase.

Why:

* It would be great to use firebase authentication more easily.

This Commit:

* Merges the [torii-fire] addon into emberfire
* This adds a torii adapter for firebase

[torii-fire]: https://github.com/MattMSumner/torii-fire