### PR TITLE
added ember-lodash as a dependancy and replaced Ember.EnuerableUtils

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -1,13 +1,13 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 import toPromise from '../utils/to-promise';
+import forEach from 'lodash/collection/forEach';
+import filter from 'lodash/collection/filter';
+import map from 'lodash/collection/map';
+import indexOf from 'lodash/array/indexOf';
 
 var fmt = Ember.String.fmt;
 var Promise = Ember.RSVP.Promise;
-var forEach = Ember.EnumerableUtils.forEach;
-var filter = Ember.EnumerableUtils.filter;
-var map = Ember.EnumerableUtils.map;
-var indexOf = Ember.EnumerableUtils.indexOf;
 
 var uniq = function (arr) {
   var ret = Ember.A();

--- a/addon/serializers/firebase.js
+++ b/addon/serializers/firebase.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import DS from 'ember-data';
+import map from 'lodash/collection/map';
 
-var map = Ember.EnumerableUtils.map;
 var fmt = Ember.String.fmt;
 
 /**

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "ember-cli-babel": "5.0.0",
+    "ember-lodash": "0.0.3",
     "fs-extra": "0.20.0",
     "rsvp": "3.0.18"
   },
@@ -74,6 +75,7 @@
     "ember-disable-prototype-extensions": "1.0.1",
     "ember-disable-proxy-controllers": "1.0.0",
     "ember-export-application-global": "1.0.2",
+    "lodash": "3.10.0",
     "ember-try": "0.0.7",
     "glob": "4.5.0",
     "gulp": "3.9.0",

--- a/vendor/legacy/header.js
+++ b/vendor/legacy/header.js
@@ -7,3 +7,13 @@
  * https://github.com/firebase/emberfire/
  * License: MIT
  */
+
+ /**
+ * @license
+ * lodash 3.10.0 (Custom Build) <https://lodash.com/>
+ * Build: `lodash modularize modern exports="es" -o ./`
+ * Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+ * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
+ * Copyright 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ * Available under MIT license <https://lodash.com/license>
+ */


### PR DESCRIPTION
My attempt to fix a 1.13 compatibility bug, #267 

Ember.EnumerableUtils is deprecated #269 

Tests are all passing, let me know if you'd like to take another approach, happy to help and modify this in any way.