### PR TITLE
updating for new serialiser api

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -209,9 +209,9 @@ export default DS.Adapter.extend(Ember.Evented, {
 
       if (!record || !record.__listening) {
         var payload = adapter._assignIdToPayload(snapshot);
-        var serializer = store.serializerFor(modelName);
+        var normalizedData = store.normalize(typeClass.modelName, payload);
         adapter._updateRecordCacheForType(typeClass, payload);
-        record = store.push(modelName, serializer.extractSingle(store, typeClass, payload));
+        store.push(normalizedData);
       }
 
       if (record) {
@@ -340,8 +340,8 @@ export default DS.Adapter.extend(Ember.Evented, {
 
       this._enqueue(function FirebaseAdapter$enqueueStorePush() {
         if (!store.isDestroying) {
-          var serializer = store.serializerFor(typeClass.modelName);
-          store.push(typeClass.modelName, serializer.extractSingle(store, typeClass, payload));
+          var normalizedData = store.normalize(typeClass.modelName, payload);
+          store.push(normalizedData);
         }
       });
     }

--- a/tests/integration/queries-test.js
+++ b/tests/integration/queries-test.js
@@ -26,7 +26,8 @@ describe('Integration: FirebaseAdapter - Queries', function() {
 
     Ember.run(function () {
       adapter.query(store, store.modelFor('post'), query, queryArray)
-        .then(() => {
+        .then((records) => {
+          queryArray.load(records);
           done();
         });
     });

--- a/tests/integration/serializer-test.js
+++ b/tests/integration/serializer-test.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import startApp from 'dummy/tests/helpers/start-app';
 import { it } from 'ember-mocha';
-import sinon from 'sinon';
 import stubFirebase from 'dummy/tests/helpers/stub-firebase';
 import unstubFirebase from 'dummy/tests/helpers/unstub-firebase';
 import createTestRef from 'dummy/tests/helpers/create-test-ref';
@@ -104,114 +103,6 @@ describe("Integration: FirebaseSerializer", function() {
 
   });
 
-  describe("#extractSingle()", function() {
-
-    describe("normalized payload", function() {
-
-      var posts, spy, extractedArray;
-
-      beforeEach(function(done) {
-        spy = sinon.spy(serializer, "extractSingle");
-        firebaseTestRef
-          .child("blogs/normalized/posts")
-          .once("value", function(snapshot) {
-            posts = snapshotToArray(snapshot);
-            extractedArray = serializer.extractArray(store, store.modelFor("post"), posts);
-            done();
-          });
-      });
-
-      it("was called for each item in the payload", function() {
-        assert.equal(spy.callCount, posts.length);
-      });
-
-      afterEach(function() {
-        spy.restore();
-      });
-
-    });
-
-    describe("denormalized payload", function() {
-
-      var posts, spy, extractedArray;
-
-      beforeEach(function(done) {
-
-        defineModel(app, 'post2', {
-          title: DS.attr('string'),
-          comments: DS.hasMany("comment", { async: false, embedded: true })
-        });
-
-        spy = sinon.spy(serializer, "extractSingle");
-        firebaseTestRef
-          .child("blogs/denormalized/posts")
-          .once("value", function(snapshot) {
-            posts = snapshotToArray(snapshot);
-            Ember.run(function() {
-              extractedArray = serializer.extractArray(store, store.modelFor('post2'), posts);
-              done();
-            });
-          });
-      });
-
-      it("was called for each item in the payload", function() {
-        assert.equal(spy.callCount, 2);
-      });
-
-      it("pushed the embedded records into the store", function() {
-        var hasComments = function(ids) {
-          return Ember.A(ids).every(function(id) {
-            return store.hasRecordForId("comment", id);
-          });
-        };
-        assert(hasComments(["comment_1", "comment_2"]), 'embedded records not found in store');
-      });
-
-      afterEach(function() {
-        spy.restore();
-      });
-
-    });
-
-  });
-
-
-  describe("#extractArray()", function() {
-
-    describe("normalized payload", function() {
-
-      var posts, spy, extractedArray;
-
-      beforeEach(function(done) {
-        spy = sinon.spy(serializer, "extractArray");
-        firebaseTestRef
-          .child("blogs/normalized/posts")
-          .once("value", function(snapshot) {
-            posts = snapshotToArray(snapshot);
-            extractedArray = serializer.extractArray(store, store.modelFor("post"), posts);
-            done();
-          });
-      });
-
-      it("was called once", function() {
-        assert.equal(spy.callCount, 1);
-      });
-
-      it("returns an array", function() {
-        assert(Ember.isArray(extractedArray));
-      });
-
-      it("the returned array contains the correct number of items", function() {
-        assert(extractedArray.length, 2);
-      });
-
-      afterEach(function() {
-        spy.restore();
-      });
-
-    });
-
-  });
 
   // TODO: make this work
   /*describe("#serializeHasMany()", function() {


### PR DESCRIPTION
I gave a shot at updating to the new serialiser API but there are some errors on the test that I'm not able to find out where to fix it, I believe it's related to the new format that Ember Data is expecting?

There might be issues with the queries tests too, I managed to get them to pass adding `queryArray.load(records);` as the queryArray turned out to be empty.