### PR TITLE
Added missing Torii authentication piece

### DIFF
--- a/addon/torii-adapters/firebase.js
+++ b/addon/torii-adapters/firebase.js
@@ -1,0 +1,39 @@
+import Ember from 'ember';
+
+export default Ember.Object.extend({
+  /**
+   * Extacts session information from authentication response
+   * @param {object} authentication - hash containing response payload
+   * @return {Promise}
+   */
+  open(authentication) {
+    return Ember.RSVP.resolve({
+      provider: authentication.provider,
+      currentUser: authentication[authentication.provider]
+    });
+  },
+  /**
+   * Restore existing authenticated session
+   * @return {Promise}
+   */
+  fetch() {
+    let firebase = this.get('firebase');
+    return new Ember.RSVP.Promise((resolve, reject)=>{
+      let auth = firebase.getAuth();
+      if (!auth) {
+        reject("No session available");
+      } else {
+        resolve(this.open(auth));
+      }
+    }, "Firebase Torii Adapter#fetch Firebase session");
+  },
+  /**
+   * Close existing authenticated session
+   * @return {Promise}
+   */
+  close() {
+    let firebase = this.get('firebase');
+    firebase.unauth();
+    return Ember.RSVP.resolve();
+  }
+});

--- a/tests/unit/torii-adapters/firebase-test.js
+++ b/tests/unit/torii-adapters/firebase-test.js
@@ -1,0 +1,72 @@
+import Ember from 'ember';
+import { describeModule, it } from 'ember-mocha';
+import sinon from 'sinon';
+
+describeModule('torii-adapter:firebase', 'FirebaseToriiAdapter', {
+  needs: ['service:firebase'],
+}, function() {
+
+  describe('#open', function() {
+    it('returns Promise that resolves to currentUser', function() {
+      const adapter = this.subject();
+      const currentUser = { handle: 'bob' };
+
+      Ember.run(function() {
+        const result = adapter.open({provider: 'twitter', twitter: currentUser});
+        assert.ok(result instanceof Ember.RSVP.Promise, 'return is a promise');
+        result.then(function(session){
+          assert.equal(session.provider, 'twitter', 'provider is passed to resolved value');
+          assert.deepEqual(session.currentUser, currentUser);
+        });
+      });
+    });
+  });
+
+  describe('#fetch', function(){
+    it('returns session information when user logged in', function(){
+      const adapter = this.subject();
+      const currentUser = {handle: 'bob'};
+      const firebaseMock = {
+        getAuth: sinon.stub().returns({provider: 'twitter', twitter: currentUser})
+      };
+      adapter.set('firebase', firebaseMock);
+
+      Ember.run(function(){
+        const result = adapter.fetch();
+        assert.ok(result instanceof Ember.RSVP.Promise, 'return is a promise');
+        result.then(function(session){
+          assert.equal(session.provider, 'twitter', 'provider is passed to resolved value');
+          assert.deepEqual(session.currentUser, currentUser);
+        });
+      });
+    });
+
+    it('resolves with an error when session is not available', function(){
+      const adapter = this.subject();
+      const firebaseMock = {
+        getAuth: sinon.stub().returns(null)
+      };
+      adapter.set('firebase', firebaseMock);
+
+      const result = adapter.fetch();
+      assert.ok(result instanceof Ember.RSVP.Promise, 'return is a promise');
+      result.catch(function(reason){
+        assert.ok(reason, 'provides fail reason');
+      });
+    });
+  });
+
+  describe('#close', function(){
+    it('calls firebase.unauth()', function(){
+      const adapter = this.subject();
+      const firebaseMock = {
+        unauth: sinon.stub()
+      };
+      adapter.set('firebase', firebaseMock);
+
+      const result = adapter.close();
+      assert.ok(result instanceof Ember.RSVP.Promise, 'return is a promise');
+      assert.ok(firebaseMock.unauth.calledOnce, "unauth was called");
+    });
+  });
+});

--- a/tests/unit/torii-providers/firebase-test.js
+++ b/tests/unit/torii-providers/firebase-test.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { describeModule, it } from 'ember-mocha';
 import sinon from 'sinon';
 
-describeModule('torii-provider:firebase', 'FirebaseProvider', {
+describeModule('torii-provider:firebase', 'FirebaseToriiProvider', {
   needs: ['service:firebase'],
 }, function() {
 


### PR DESCRIPTION
Torii needs an adapter that's used to bridge authenticated service with the app. Adapters have 3 methods: 

* `open` called when session is opened (and return session information`
* `fetch` called to retrieve existing session (succeeds or fails depending on session availability)
* `close` called to delete session

This adapter provides code necessary to perform this operations with Firebase.

To use it in the app, create a `torii-adapters/application.js` with following code
```js
import Ember from 'ember';
import ToriiFirebaseAdapter from 'emberfire/torii-adapters/firebase';

export default ToriiFirebaseAdapter.extend({
  firebase: Ember.inject.service()
});
```