### PR TITLE
Add `password` auth provider and change `authWith` param

### DIFF
--- a/addon/torii-adapters/firebase.js
+++ b/addon/torii-adapters/firebase.js
@@ -9,6 +9,7 @@ export default Ember.Object.extend({
   open(authentication) {
     return Ember.RSVP.resolve({
       provider: authentication.provider,
+      uid: authentication.uid,
       currentUser: authentication[authentication.provider]
     });
   },

--- a/addon/torii-providers/firebase.js
+++ b/addon/torii-providers/firebase.js
@@ -6,14 +6,40 @@ export default Ember.Object.extend({
   open: function(options) {
     var self = this;
 
-    return new Ember.RSVP.Promise(function(resolve, reject) {
-      self.get('firebase').authWithOAuthPopup(options.authWith, function(error, authData) {
-        if (error) {
-          reject(error);
-        } else {
-          resolve(authData);
+    var provider = options.authWith || options.provider;
+
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      if (!provider) {
+        reject(new Error('`provider` must be supplied'));
+      }
+
+      if (provider === 'password') {
+        if (!options.email && !options.password) {
+          reject(new Error('`email` and `password` must be supplied'));
         }
-      });
+
+        this.get('firebase').authWithPassword({
+          email: options.email,
+          password: options.password,
+        }, (error, authData) => {
+
+          if (error) {
+            reject(error);
+          } else {
+            resolve(authData);
+          }
+        });
+
+      } else {
+        this.get('firebase').authWithOAuthPopup(provider, (error, authData) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(authData);
+          }
+        });
+      }
+
     });
   }
 });

--- a/addon/torii-providers/firebase.js
+++ b/addon/torii-providers/firebase.js
@@ -4,7 +4,7 @@ export default Ember.Object.extend({
   firebase: Ember.inject.service(),
 
   open: function(options) {
-    var provider = options.authWith || options.provider;
+    var provider = options.provider || options.authWith;
 
     return new Ember.RSVP.Promise((resolve, reject) => {
       if (!provider) {

--- a/addon/torii-providers/firebase.js
+++ b/addon/torii-providers/firebase.js
@@ -4,8 +4,6 @@ export default Ember.Object.extend({
   firebase: Ember.inject.service(),
 
   open: function(options) {
-    var self = this;
-
     var provider = options.authWith || options.provider;
 
     return new Ember.RSVP.Promise((resolve, reject) => {

--- a/blueprints/emberfire/index.js
+++ b/blueprints/emberfire/index.js
@@ -27,7 +27,7 @@ module.exports = {
       return self.addToConfig('firebase', '\'' + firebaseUrl + '\'');
     })
     .then(function () {
-      return self.addToConfig('contentSecurityPolicy', '{ \'connect-src\': "\'self\' wss://*.firebaseio.com" }');
+      return self.addToConfig('contentSecurityPolicy', '{ \'connect-src\': "\'self\' https://auth.firebase.com wss://*.firebaseio.com" }');
     })
     .then(function () {
       var output = EOL;

--- a/tests/unit/torii-providers/firebase-test.js
+++ b/tests/unit/torii-providers/firebase-test.js
@@ -7,38 +7,139 @@ describeModule('torii-provider:firebase', 'FirebaseToriiProvider', {
 }, function() {
 
   describe('#open', function() {
-    it('errors when firebase.authWithOAuthPopup errors', function() {
-      let provider = this.subject();
-      let errorMock = sinon.spy();
-      const firebaseMock = {
-        authWithOAuthPopup: sinon.stub().yields(errorMock)
-      };
-      provider.set('firebase', firebaseMock);
 
-      Ember.run(function() {
-        provider.open({authWith: 'errorProvider'}).catch(function(error) {
-          assert.ok(firebaseMock.authWithOAuthPopup.calledWith('errorProvider'));
+    describe('with an OAuth provider', function () {
 
-          assert.equal(error, errorMock);
+      it('errors when firebase.authWithOAuthPopup errors', function(done) {
+        let provider = this.subject();
+        let errorMock = sinon.spy();
+        const firebaseMock = {
+          authWithOAuthPopup: sinon.stub().yields(errorMock)
+        };
+        provider.set('firebase', firebaseMock);
+
+        Ember.run(function() {
+          provider.open({authWith: 'errorProvider'}).catch(function(error) {
+            expect(firebaseMock.authWithOAuthPopup.calledWith('errorProvider')).to.be.true;
+
+            expect(error).to.equal(errorMock);
+            done();
+          });
         });
       });
-    });
 
-    it('returns authData when firebase.authWithOAuthPopup returns authData', function() {
-      let provider = this.subject();
-      let authDataMock = sinon.spy();
-      const firebaseMock = {
-        authWithOAuthPopup: sinon.stub().yields(null, authDataMock)
-      };
-      provider.set('firebase', firebaseMock);
+      it('returns authData when firebase.authWithOAuthPopup returns authData', function(done) {
+        let provider = this.subject();
+        let authDataMock = sinon.spy();
+        const firebaseMock = {
+          authWithOAuthPopup: sinon.stub().yields(null, authDataMock)
+        };
+        provider.set('firebase', firebaseMock);
 
-      Ember.run(function() {
-        provider.open({authWith: 'successProvider'}).then(function(authData) {
-          assert.ok(firebaseMock.authWithOAuthPopup.calledWith('successProvider'));
+        Ember.run(function() {
+          provider.open({provider: 'successProvider'}).then(function(authData) {
+            expect(firebaseMock.authWithOAuthPopup.calledWith('successProvider')).to.be.true;
 
-          assert.equal(authData, authDataMock);
+            expect(authData).to.equal(authDataMock);
+            done();
+          });
         });
       });
-    });
+
+    }); // with an OAuth provider
+
+
+    describe('with email/password provider', function () {
+
+      it('errors when firebase.authWithPassword errors', function(done) {
+        let provider = this.subject();
+        let errorMock = sinon.spy();
+        const firebaseMock = {
+          authWithPassword: sinon.stub().yields(errorMock)
+        };
+        provider.set('firebase', firebaseMock);
+
+        Ember.run(function() {
+          provider.open({
+            provider: 'password',
+            email: 'email',
+            password: 'password'
+          }).catch(function(error) {
+            expect(firebaseMock.authWithPassword.calledOnce).to.be.true;
+
+            expect(error).to.equal(errorMock);
+            done();
+          });
+        });
+      });
+
+      it('errors when `email` and `password` are not supplied', function(done) {
+        let provider = this.subject();
+        let errorMock = sinon.spy();
+        const firebaseMock = {
+          authWithPassword: sinon.stub().yields(errorMock)
+        };
+        provider.set('firebase', firebaseMock);
+
+        Ember.run(function() {
+          provider.open({
+            provider: 'password'
+          }).catch(function(error) {
+
+            expect(error.message).to.equal('`email` and `password` must be supplied');
+            done();
+          });
+        });
+      });
+
+      it('returns authData when firebase.authWithPassword returns authData', function(done) {
+        let provider = this.subject();
+        let authDataMock = sinon.spy();
+        const firebaseMock = {
+          authWithPassword: sinon.stub().yields(null, authDataMock)
+        };
+        provider.set('firebase', firebaseMock);
+
+        Ember.run(function() {
+          provider.open({
+            provider: 'password',
+            email: 'email',
+            password: 'password'
+          }).then(function(authData) {
+            expect(firebaseMock.authWithPassword.calledOnce).to.be.true;
+
+            expect(authData).to.equal(authDataMock);
+            done();
+          });
+        });
+      });
+
+      it('passes email and password parameters through to authWithPassword', function(done) {
+        let provider = this.subject();
+        let authDataMock = sinon.spy();
+        const firebaseMock = {
+          authWithPassword: sinon.stub().yields(null, authDataMock)
+        };
+        provider.set('firebase', firebaseMock);
+
+        Ember.run(function() {
+          provider.open({
+            provider: 'password',
+            email: 'email',
+            password: 'password'
+          }).then(function(authData) {
+            expect(firebaseMock.authWithPassword.calledWith({
+              email: 'email',
+              password: 'password'
+            })).to.be.true;
+
+            expect(authData).to.equal(authDataMock);
+            done();
+          });
+        });
+      });
+
+    }); // with email/password provider
+
   });
 });

--- a/tests/unit/torii-providers/firebase-test.js
+++ b/tests/unit/torii-providers/firebase-test.js
@@ -19,7 +19,7 @@ describeModule('torii-provider:firebase', 'FirebaseToriiProvider', {
         provider.set('firebase', firebaseMock);
 
         Ember.run(function() {
-          provider.open({authWith: 'errorProvider'}).catch(function(error) {
+          provider.open({provider: 'errorProvider'}).catch(function(error) {
             expect(firebaseMock.authWithOAuthPopup.calledWith('errorProvider')).to.be.true;
 
             expect(error).to.equal(errorMock);


### PR DESCRIPTION
- Changed `authWith` to `provider`. People are more likely to remember the latter.
  
  ```js
  this.get('session').open('firebase', { provider: 'github' });
  ```

- Added `password` provider

  ```js
  this.get('session').open('firebase', {
    provider: 'password',
    email: 'a@b.com',
    password: 'pass'
  });
  ```