### PR TITLE
Replace `Ember.String.fmt` with ES6 strings

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -8,7 +8,6 @@ import includes from 'lodash/collection/includes';
 import indexOf from 'lodash/array/indexOf';
 import find from 'lodash/collection/find';
 
-var fmt = Ember.String.fmt;
 var Promise = Ember.RSVP.Promise;
 
 var uniq = function (arr) {
@@ -108,7 +107,7 @@ export default DS.Adapter.extend(Ember.Evented, {
         var payload = adapter._assignIdToPayload(snapshot);
         adapter._updateRecordCacheForType(typeClass, payload);
         if (payload === null) {
-          var error = new Error(fmt('no record was found at %@', [ref.toString()]));
+          var error = new Error(`no record was found at ${ref.toString()}`);
               error.recordId = id;
           reject(error);
         }
@@ -119,7 +118,7 @@ export default DS.Adapter.extend(Ember.Evented, {
       function(err) {
         reject(err);
       });
-    }, fmt('DS: FirebaseAdapter#findRecord %@ to %@', [typeClass.modelName, ref.toString()]));
+    }, `DS: FirebaseAdapter#findRecord ${typeClass.modelName} to ${ref.toString()}`);
   },
 
   recordWasPushed: function(store, modelName, record) {
@@ -208,7 +207,7 @@ export default DS.Adapter.extend(Ember.Evented, {
       }, function(error) {
         reject(error);
       });
-    }, fmt('DS: FirebaseAdapter#findAll %@ to %@', [typeClass.modelName, ref.toString()]));
+    }, `DS: FirebaseAdapter#findAll ${typeClass.modelName} to ${ref.toString()}`);
   },
 
   query: function(store, typeClass, query, recordArray) {
@@ -268,7 +267,7 @@ export default DS.Adapter.extend(Ember.Evented, {
       }, function(error) {
         reject(error);
       });
-    }, fmt('DS: FirebaseAdapter#query %@ with %@', [modelName, query]));
+    }, `DS: FirebaseAdapter#query ${modelName} with ${query}`);
   },
 
   applyQueryToRef: function (ref, query) {
@@ -419,14 +418,14 @@ export default DS.Adapter.extend(Ember.Evented, {
         }
         // Throw an error if any of the relationships failed to save
         if (rejected.length !== 0) {
-          var error = new Error(fmt('Some errors were encountered while saving %@ %@', [typeClass, snapshot.id]));
+          var error = new Error(`Some errors were encountered while saving ${typeClass} ${snapshot.id}`);
               error.errors = rejected.mapBy('reason');
           reject(error);
         } else {
           resolve();
         }
       });
-    }, fmt('DS: FirebaseAdapter#updateRecord %@ to %@', [typeClass, recordRef.toString()]));
+    }, `DS: FirebaseAdapter#updateRecord ${typeClass} to ${recordRef.toString()}`);
   },
 
   //Just update the record itself without caring for the relationships
@@ -480,7 +479,7 @@ export default DS.Adapter.extend(Ember.Evented, {
         return savedRecords;
       }
       else {
-        var error = new Error(fmt('Some errors were encountered while saving a hasMany relationship %@ -> %@', [relationship.parentType, relationship.type]));
+        var error = new Error(`Some errors were encountered while saving a hasMany relationship ${relationship.parentType} -> ${relationship.type}`);
             error.errors = Ember.A(rejected).mapBy('reason');
         throw error;
       }

--- a/addon/serializers/firebase.js
+++ b/addon/serializers/firebase.js
@@ -2,8 +2,6 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import assign from 'lodash/object/assign';
 
-var fmt = Ember.String.fmt;
-
 /**
  * The Firebase serializer helps normalize relationships and can be extended on
  * a per model basis.
@@ -85,7 +83,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
             } else if (Ember.isArray(payload[key])) {
               payload[key] = this._addNumericIdsToEmbeddedArray(payload[key]);
             } else {
-              throw new Error(fmt('%@ relationship %@(\'%@\') must contain embedded records with an `id`. Example: { "%@": { "%@_1": { "id": "%@_1" } } } instead got: %@', [modelClass.toString(), meta.kind, meta.type, key, meta.type, meta.type, JSON.stringify(payload[key])] ));
+              throw new Error(`${modelClass.toString()} relationship ${meta.kind}('${meta.type}') must contain embedded records with an \`id\`. Example: { "${key}": { "${meta.type}_1": { "id": "${meta.type}_1" } } } instead got: ${JSON.stringify(payload[key])}`);
             }
           }
 
@@ -96,7 +94,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
             } else if (Ember.isArray(payload[key])) {
               payload[key] = this._convertBooleanArrayToIds(payload[key]);
             } else {
-              throw new Error(fmt('%@ relationship %@(\'%@\') must be a key/value map. Example: { "%@": { "%@_1": true } } instead got: %@', [modelClass.toString(), meta.kind, meta.type, key, meta.type, JSON.stringify(payload[key])] ));
+              throw new Error(`${modelClass.toString()} relationship ${meta.kind}('${meta.type}') must be a key/value map. Example: { "${key}": { "${meta.type}_1": true } } instead got: ${JSON.stringify(payload[key])}`);
             }
           }
 
@@ -203,7 +201,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
     for (var i = 0; i <  arr.length; i++) {
       if (arr[i]) {
         if (typeof arr[i] !== 'object') {
-          throw new Error(fmt('expecting embedded object hash but found %@', [JSON.stringify(arr[i])] ));
+          throw new Error(`expecting embedded object hash but found ${JSON.stringify(arr[i])}`);
         }
         result.push(assign({ id: '' + i }, arr[i]));
       }

--- a/tests/dummy/app/models/comment.js
+++ b/tests/dummy/app/models/comment.js
@@ -1,14 +1,12 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-let fmt = Ember.String.fmt;
-
 export default DS.Model.extend({
   body: DS.attr('string'),
   published: DS.attr('number'),
   publishedDate: Ember.computed('published', function() {
     var m = moment(this.get('published'));
-    return fmt('%@ at %@', m.format('MMMM Do, YYYY'), m.format('h:mm:ss a'));
+    return `${m.format('MMMM Do, YYYY')} at ${m.format('h:mm:ss a')}`;
   }),
   user: DS.belongsTo('user', { async: true })
 });


### PR DESCRIPTION
Hi, since Ember 2.0.0 `Ember.String.fmt` is gone and we should use ES6 literals. I've replaced all I could find and it seems to work.

Would be great if you could make sure I didn't mess up, though.

Thanks!