### PR TITLE
Adds recommended torii adapter as a blueprint

### DIFF
--- a/blueprints/firebase-torii-adapter/files/app/torii-adapters/application.js
+++ b/blueprints/firebase-torii-adapter/files/app/torii-adapters/application.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import ToriiFirebaseAdapter from 'emberfire/torii-adapters/firebase';
+
+export default ToriiFirebaseAdapter.extend({
+  firebase: Ember.inject.service()
+});

--- a/blueprints/firebase-torii-adapter/index.js
+++ b/blueprints/firebase-torii-adapter/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  normalizeEntityName: function() {
+    // this prevents an error when the entityName is
+    // not specified (since that doesn't actually matter
+    // to us
+  },
+
+  description: 'Generates a default Torii adapter to authenticate with Firebase.'
+};


### PR DESCRIPTION
In the current documentation, there is boilerplate code to pull in the default Emberfire Torii adapter.

While I agree that this module should not be in the default blueprint, I think that it would be much better to have a separate blueprint available to install the suggested adapter rather than requesting copy-pasta.