### PR TITLE
Run Travis tests against the latest stable version of Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - stable
 
 sudo: false
 


### PR DESCRIPTION
So that we don't need to bump the Node version every time they release a new version.