### PR TITLE
Add support and documentation for use as nested addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ This will create a `app/adapters/application.js`. All you need to do is update y
 
 Your Firebase data will now be synced with the Ember Data store. For detailed EmberFire documentation, check out the [quickstart](https://firebase.com/docs/web/libraries/ember/quickstart.html) or [guide](https://firebase.com/docs/web/libraries/ember/guide.html) in the Firebase docs.
 
+### Nested Addon Usage Caveat
+
+To publish an addon that exports functionality driven by EmberFire,
+note that EmberFire must be listed in the `dependencies` for NPM
+and not the `devDependencies`.
+
+When consuming an addon that consumes EmberFire, running the
+initializing generator by hand is required.
+
+```sh
+ember generate ../node_modules/your-addon/node_modules/emberfire/blueprints/emberfire
+```
+
+
 ## Using EmberFire without ember-cli
 
 EmberFire also works without ember-cli. See the [Firebase documentation](https://firebase.com/docs/web/libraries/ember/guide.html#section-without-ember-cli) for instructions on getting started.

--- a/index.js
+++ b/index.js
@@ -7,6 +7,12 @@ module.exports = {
   included: function included(app) {
     this._super.included(app);
 
+    // make sure app is correctly assigned when being used as a nested addon
+    if (app.app) {
+      app = app.app;
+    }
+    this.app = app;
+
     this.app.import({
       development: app.bowerDirectory + '/firebase/firebase-debug.js',
       production: app.bowerDirectory + '/firebase/firebase.js'


### PR DESCRIPTION
Allows EmberFire to be used in another addon. Implementation taken from https://github.com/rwjblue/ember-cli-pretender/commit/dda9bf88597e5f127cfbe0cf863f2b03c4e24246