### PR TITLE
Accept optional auth settings

### DIFF
--- a/addon/torii-providers/firebase.js
+++ b/addon/torii-providers/firebase.js
@@ -54,7 +54,7 @@ export default Ember.Object.extend({
           } else {
             resolve(authData);
           }
-        });
+        }, (options.settings || {}));
       }
 
     });


### PR DESCRIPTION
Provides support for the "Optional Settings" (generally `remember` & `scope`) accepted by the [Facebook][f], [Twitter][t], [GitHub][gh] and [Google][g] auth providers.

[f]: https://www.firebase.com/docs/web/guide/login/facebook.html#section-logging-in
[t]: https://www.firebase.com/docs/web/guide/login/twitter.html#section-logging-in)
[gh]: https://www.firebase.com/docs/web/guide/login/github.html#section-logging-in
[g]: https://www.firebase.com/docs/web/guide/login/google.html#section-logging-in

See for example the [custom Facebook scopes](https://www.firebase.com/docs/web/guide/login/facebook.html#section-scope)

Called `settings` rather than `options` for consistency with Firebase docs