### PR TITLE
wrap firebase auth with test waiters

### DIFF
--- a/addon/torii-providers/firebase.js
+++ b/addon/torii-providers/firebase.js
@@ -11,15 +11,22 @@ export default Ember.Object.extend({
         reject(new Error('`provider` must be supplied'));
       }
 
+      var waiter = (() => false);
       if (provider === 'password') {
         if (!options.email && !options.password) {
           reject(new Error('`email` and `password` must be supplied'));
         }
 
+        if (Ember.testing){
+          Ember.Test.registerWaiter(waiter);
+        }
         this.get('firebase').authWithPassword({
           email: options.email,
           password: options.password,
         }, (error, authData) => {
+          if (Ember.testing){
+            Ember.Test.unregisterWaiter(waiter);
+          }
 
           if (error) {
             reject(error);
@@ -32,7 +39,13 @@ export default Ember.Object.extend({
         if (!options.token) {
           reject(new Error('A token must be supplied'));
         }
+        if (Ember.testing){
+          Ember.Test.registerWaiter(waiter);
+        }
         this.get('firebase').authWithCustomToken(options.token, (error, authData) => {
+          if (Ember.testing){
+            Ember.Test.unregisterWaiter(waiter);
+          }
           if (error) {
             reject(error);
           } else {
@@ -40,7 +53,13 @@ export default Ember.Object.extend({
           }
         });
       } else if (provider === 'anonymous') {
+        if (Ember.testing){
+          Ember.Test.registerWaiter(waiter);
+        }
         this.get('firebase').authAnonymously((error, authData) => {
+          if (Ember.testing){
+            Ember.Test.unregisterWaiter(waiter);
+          }
           if (error) {
             reject(error);
           } else {
@@ -48,7 +67,13 @@ export default Ember.Object.extend({
           }
         });
       } else {
+        if (Ember.testing){
+          Ember.Test.registerWaiter(waiter);
+        }
         this.get('firebase').authWithOAuthPopup(provider, (error, authData) => {
+          if (Ember.testing){
+            Ember.Test.unregisterWaiter(waiter);
+          }
           if (error) {
             reject(error);
           } else {


### PR DESCRIPTION
fixes #312

I've added the wrapper to the OAuth popup login path too, though it's not totally clear how this interacts with an ember acceptance test: running the tests in the browser seems seems to work with facebook login (so long as I've already authenticated the browser with the app manually) but I haven't thoroughly tested with other OAuth providers 