### PR TITLE
Fixing error when Ember extensions are disabled

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -419,7 +419,7 @@ export default DS.Adapter.extend(Ember.Evented, {
         // Throw an error if any of the relationships failed to save
         if (rejected.length !== 0) {
           var error = new Error(`Some errors were encountered while saving ${typeClass} ${snapshot.id}`);
-              error.errors = rejected.mapBy('reason');
+          error.errors = Ember.A(rejected).mapBy('reason');
           reject(error);
         } else {
           resolve();


### PR DESCRIPTION
`Ember.A().filter` returns a javascript array, so it needs to be cast to an `Ember.A` before we can call mapBy.

An alternate implementation could use `Array.map`, but this fixes my current problem.

Can add tests, but I would like to propose turning the Ember extensions off in the tests so that this kind of errors are surfaced.