### PR TITLE
Save relationships in a single atomic save

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -3,25 +3,9 @@ import DS from 'ember-data';
 import Waitable from '../mixins/waitable';
 import toPromise from '../utils/to-promise';
 import forEach from 'lodash/collection/forEach';
-import filter from 'lodash/collection/filter';
-import map from 'lodash/collection/map';
-import includes from 'lodash/collection/includes';
-import indexOf from 'lodash/array/indexOf';
 import find from 'lodash/collection/find';
 
 var Promise = Ember.RSVP.Promise;
-
-var uniq = function (arr) {
-  var ret = Ember.A();
-
-  arr.forEach(function(k) {
-    if (indexOf(ret, k) < 0) {
-      ret.push(k);
-    }
-  });
-
-  return ret;
-};
 
 
 /**
@@ -67,8 +51,6 @@ export default DS.Adapter.extend(Waitable, {
     this._ref = firebase.ref();
     // Keep track of what types `.findAll()` has been called for
     this._findAllMapForType = {};
-    // Keep a cache to check modified relationships against
-    this._recordCacheForType = {};
     // Used to batch records into the store
     this._queue = [];
   },
@@ -115,7 +97,6 @@ export default DS.Adapter.extend(Waitable, {
 
     return this._fetch(ref, log).then((snapshot) => {
       var payload = this._assignIdToPayload(snapshot);
-      this._updateRecordCacheForType(typeClass, payload);
       if (payload === null) {
         var error = new Error(`no record was found at ${ref.toString()}`);
             error.recordId = id;
@@ -231,7 +212,6 @@ export default DS.Adapter.extend(Waitable, {
       var results = [];
       snapshot.forEach((childSnapshot) => {
         var payload = this._assignIdToPayload(childSnapshot);
-        this._updateRecordCacheForType(typeClass, payload);
         results.push(payload);
       });
 
@@ -252,7 +232,6 @@ export default DS.Adapter.extend(Waitable, {
       if (!record || !record.__listening) {
         var payload = this._assignIdToPayload(snapshot);
         var normalizedData = store.normalize(typeClass.modelName, payload);
-        this._updateRecordCacheForType(typeClass, payload);
         record = store.push(normalizedData);
       }
 
@@ -289,7 +268,6 @@ export default DS.Adapter.extend(Waitable, {
       var results = [];
       snapshot.forEach((childSnapshot) => {
         var payload = this._assignIdToPayload(childSnapshot);
-        this._updateRecordCacheForType(typeClass, payload);
         results.push(payload);
       });
       return results;
@@ -400,16 +378,13 @@ export default DS.Adapter.extend(Waitable, {
    * method on a model record instance.
    *
    * The `updateRecord` method serializes the record and performs an `update()`
-   * at the the Firebase location and a `.set()` at any relationship locations
-   * The method will return a promise which will be resolved when the data and
-   * any relationships have been successfully saved to Firebase.
+   * at the the Firebase location.
    *
    * We take an optional record reference, in order for this method to be usable
    * for saving nested records as well.
    */
   updateRecord(store, typeClass, snapshot) {
     var recordRef = this._getAbsoluteRef(snapshot.record);
-    var recordCache = this._getRecordCache(typeClass, snapshot.id);
 
     var pathPieces = recordRef.path.toString().split('/');
     var lastPiece = pathPieces[pathPieces.length-1];
@@ -417,44 +392,48 @@ export default DS.Adapter.extend(Waitable, {
       includeId: (lastPiece !== snapshot.id) // record has no firebase `key` in path
     });
 
-    return new Promise((resolve, reject) => {
-      var savedRelationships = Ember.A();
-      snapshot.record.eachRelationship((key, relationship) => {
-        var save;
+    return this._updateRecord(recordRef, serializedRecord).then(() => {
+      return this._cleanEmbeddedChildren(store, typeClass, snapshot);
+    }).then(() => {
+      // required, tells ember data that the data we saved is the last known
+      // server state. Equivalent is to return `serializedRecord`.
+      return undefined;
+    });
+
+    // TODO: add promise label:
+    // `DS: FirebaseAdapter#updateRecord ${typeClass} to ${recordRef.toString()}`);
+  },
+
+  /**
+   * Recursively removes the `dirty` state on all embedded children.
+   *
+   * @param  {DS.Store} store
+   * @param  {Class} typeClass
+   * @param  {DS.Snapshot} snapshot
+   * @private
+   */
+  _cleanEmbeddedChildren: function (store, typeClass, snapshot) {
+    var embeddedSnapshots = [];
+    snapshot.eachRelationship((key, relationship) => {
+      if (this.isRelationshipEmbedded(store, typeClass.modelName, relationship)) {
         if (relationship.kind === 'hasMany') {
-          if (serializedRecord[key]) {
-            save = this._saveHasManyRelationship(store, typeClass, relationship, serializedRecord[key], recordRef, recordCache);
-            savedRelationships.push(save);
-            // Remove the relationship from the serializedRecord because otherwise we would clobber the entire hasMany
-            delete serializedRecord[key];
-          }
+          snapshot.hasMany(key).forEach(function (childSnapshot) {
+            embeddedSnapshots.push(childSnapshot);
+          });
         } else {
-          if (this.isRelationshipEmbedded(store, typeClass.modelName, relationship) && serializedRecord[key]) {
-            save = this._saveEmbeddedBelongsToRecord(store, typeClass, relationship, serializedRecord[key], recordRef);
-            savedRelationships.push(save);
-            delete serializedRecord[key];
+          if (snapshot.belongsTo(key)) {
+            embeddedSnapshots.push(snapshot.belongsTo(key));
           }
         }
-      });
+      }
+    });
 
-      var relationshipsPromise = Ember.RSVP.allSettled(savedRelationships);
-      var recordPromise = this._updateRecord(recordRef, serializedRecord);
-
-      Ember.RSVP.hashSettled({relationships: relationshipsPromise, record: recordPromise}).then((promises) => {
-        var rejected = Ember.A(promises.relationships.value).filterBy('state', 'rejected');
-        if (promises.record.state === 'rejected') {
-          rejected.push(promises.record);
-        }
-        // Throw an error if any of the relationships failed to save
-        if (rejected.length !== 0) {
-          var error = new Error(`Some errors were encountered while saving ${typeClass} ${snapshot.id}`);
-          error.errors = Ember.A(rejected).mapBy('reason');
-          reject(error);
-        } else {
-          resolve();
-        }
-      });
-    }, `DS: FirebaseAdapter#updateRecord ${typeClass} to ${recordRef.toString()}`);
+    embeddedSnapshots.forEach((childSnapshot) => {
+      this._cleanEmbeddedChildren(store, childSnapshot.type, childSnapshot);
+      childSnapshot._internalModel.flushChangedAttributes();
+      childSnapshot._internalModel.adapterWillCommit();
+      childSnapshot._internalModel.adapterDidCommit();
+    });
   },
 
 
@@ -466,79 +445,6 @@ export default DS.Adapter.extend(Waitable, {
    */
   _updateRecord(recordRef, serializedRecord) {
     return toPromise(recordRef.update, recordRef, [serializedRecord]);
-  },
-
-
-  /**
-   * Call _saveHasManyRelationshipRecord on each record in the relationship
-   * and then resolve once they have all settled
-   */
-  _saveHasManyRelationship(store, typeClass, relationship, ids, recordRef, recordCache) {
-    if (!Ember.isArray(ids)) {
-      throw new Error('hasMany relationships must must be an array');
-    }
-    var idsCache = Ember.A(recordCache[relationship.key]);
-    var dirtyRecords = [];
-
-    // Added
-    var addedRecords = filter(ids, (id) => {
-      return !idsCache.contains(id);
-    });
-
-    // Dirty
-    dirtyRecords = filter(ids, (id) => {
-      var relatedModelName = relationship.type;
-      return store.hasRecordForId(relatedModelName, id) && store.peekRecord(relatedModelName, id).get('hasDirtyAttributes') === true;
-    });
-
-    dirtyRecords = map(uniq(dirtyRecords.concat(addedRecords)), (id) => {
-      return this._saveHasManyRecord(store, typeClass, relationship, recordRef, id);
-    });
-
-    // Removed
-    var removedRecords = filter(idsCache, (id) => {
-      return !includes(ids, id);
-    });
-
-    removedRecords = map(removedRecords, (id) => {
-      return this._removeHasManyRecord(store, recordRef, relationship.key, id);
-    });
-    // Combine all the saved records
-    var savedRecords = dirtyRecords.concat(removedRecords);
-    // Wait for all the updates to finish
-    return Ember.RSVP.allSettled(savedRecords).then((savedRecords) => {
-      var rejected = Ember.A(Ember.A(savedRecords).filterBy('state', 'rejected'));
-      if (rejected.get('length') === 0) {
-        // Update the cache
-        recordCache[relationship.key] = ids;
-        return savedRecords;
-      }
-      else {
-        var error = new Error(`Some errors were encountered while saving a hasMany relationship ${relationship.parentType} -> ${relationship.type}`);
-            error.errors = Ember.A(rejected).mapBy('reason');
-        throw error;
-      }
-    });
-  },
-
-
-  /**
-   * If the relationship is `async: true`, create a child ref
-   * named with the record id and set the value to true
-
-   * If the relationship is `embedded: true`, create a child ref
-   * named with the record id and update the value to the serialized
-   * version of the record
-   */
-  _saveHasManyRecord(store, typeClass, relationship, parentRef, id) {
-    var ref = this._getRelationshipRef(parentRef, relationship.key, id);
-    var record = store.peekRecord(relationship.type, id);
-    var isEmbedded = this.isRelationshipEmbedded(store, typeClass.modelName, relationship);
-    if (isEmbedded) {
-      return record.save();
-    }
-
-    return toPromise(ref.set, ref,  [true]);
   },
 
 
@@ -576,20 +482,6 @@ export default DS.Adapter.extend(Waitable, {
   _removeHasManyRecord(store, parentRef, key, id) {
     var ref = this._getRelationshipRef(parentRef, key, id);
     return toPromise(ref.remove, ref, [], ref.toString());
-  },
-
-
-  /**
-   * Save an embedded belongsTo record and set its internal firebase ref
-   *
-   * @return {Promise<DS.Model>}
-   */
-  _saveEmbeddedBelongsToRecord(store, typeClass, relationship, id, parentRef) {
-    var record = store.peekRecord(relationship.type, id);
-    if (record) {
-      return record.save();
-    }
-    return Ember.RSVP.Promise.reject(new Error(`Unable to find record with id ${id} from embedded relationship: ${JSON.stringify(relationship)}`));
   },
 
 
@@ -730,42 +622,6 @@ export default DS.Adapter.extend(Waitable, {
     } else {
       callback.apply(null, args);
     }
-  },
-
-
-  /**
-   * A cache of hasMany relationships that can be used to
-   * diff against new relationships when a model is saved
-   */
-  _recordCacheForType: undefined,
-
-
-  /**
-   * _updateHasManyCacheForType
-   */
-  _updateRecordCacheForType(typeClass, payload) {
-    if (!payload) { return; }
-    var id = payload.id;
-    var cache = this._getRecordCache(typeClass, id);
-    // Only cache relationships for now
-    typeClass.eachRelationship((key, relationship) => {
-      if (relationship.kind === 'hasMany') {
-        var ids = payload[key];
-        cache[key] = !Ember.isNone(ids) ? Ember.A(Object.keys(ids)) : Ember.A();
-      }
-    });
-  },
-
-
-  /**
-   * Get or create the cache for a record
-   */
-  _getRecordCache(typeClass, id) {
-    var modelName = typeClass.modelName;
-    var cache = this._recordCacheForType;
-    cache[modelName] = cache[modelName] || {};
-    cache[modelName][id] = cache[modelName][id] || {};
-    return cache[modelName][id];
   },
 
 

--- a/tests/helpers/setup-store.js
+++ b/tests/helpers/setup-store.js
@@ -1,0 +1,104 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+
+export default function setupStore(options) {
+  var container, registry;
+  var env = {};
+  options = options || {};
+
+  if (Ember.Registry) {
+    registry = env.registry = new Ember.Registry();
+    container = env.container = registry.container();
+  } else {
+    container = env.container = new Ember.Container();
+    registry = env.registry = container;
+  }
+
+  env.replaceContainerNormalize = function replaceContainerNormalize(fn) {
+    if (env.registry) {
+      env.registry.normalize = fn;
+    } else {
+      env.container.normalize = fn;
+    }
+  };
+
+  var adapter = env.adapter = (options.adapter || '-default');
+  delete options.adapter;
+
+  if (typeof adapter !== 'string') {
+    env.registry.register('adapter:-ember-data-test-custom', adapter);
+    adapter = '-ember-data-test-custom';
+  }
+
+  for (var prop in options) {
+    registry.register('model:' + Ember.String.dasherize(prop), options[prop]);
+  }
+
+  registry.register('service:store', DS.Store.extend({
+    adapter: adapter
+  }));
+
+  registry.optionsForType('serializer', { singleton: false });
+  registry.optionsForType('adapter', { singleton: false });
+  registry.register('adapter:-default', DS.Adapter);
+
+  registry.register('serializer:-default', DS.JSONSerializer);
+  registry.register('serializer:-rest', DS.RESTSerializer);
+
+  registry.register('adapter:-rest', DS.RESTAdapter);
+
+  registry.register('adapter:-json-api', DS.JSONAPIAdapter);
+  registry.register('serializer:-json-api', DS.JSONAPISerializer);
+
+  registry.register('transform:string', DS.Transform.extend({
+    deserialize: function(serialized) {
+      return Ember.isNone(serialized) ? null : String(serialized);
+    },
+    serialize: function(deserialized) {
+      return Ember.isNone(deserialized) ? null : String(deserialized);
+    }
+  }));
+
+  function isNumber(value) {
+    return value === value && value !== Infinity && value !== -Infinity;
+  }
+
+  registry.register('transform:number', DS.Transform.extend({
+    deserialize: function(serialized) {
+      var transformed;
+
+      if (Ember.isEmpty(serialized)) {
+        return null;
+      } else {
+        transformed = Number(serialized);
+
+        return isNumber(transformed) ? transformed : null;
+      }
+    },
+
+    serialize: function(deserialized) {
+      var transformed;
+
+      if (Ember.isEmpty(deserialized)) {
+        return null;
+      } else {
+        transformed = Number(deserialized);
+
+        return isNumber(transformed) ? transformed : null;
+      }
+    }
+  }));
+
+  env.restSerializer = container.lookup('serializer:-rest');
+  env.store = container.lookup('service:store');
+  env.serializer = env.store.serializerFor('-default');
+  env.adapter = env.store.get('defaultAdapter');
+
+  return env;
+}
+
+export {setupStore};
+
+export function createStore(options) {
+  return setupStore(options).store;
+}


### PR DESCRIPTION
Updates the adapter to write all relationship data at the same time as the payload. This is to help interop with security and validation rules.

This also updates the adapter to rely much more on the core Ember Data `EmbeddedRecordsMixin` for all embedded serialize/deserialize operations.

related to #327, #326, #304