### PR TITLE
Cleanup object definitions/comments, arrow functions

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -22,38 +22,40 @@ var uniq = function (arr) {
   return ret;
 };
 
-/**
-  The Firebase adapter allows your store to communicate with the Firebase
-  realtime service. To use the adapter in your app, extend DS.FirebaseAdapter
-  and customize the endpoint to point to the Firebase URL where you want this
-  data to be stored.
 
-  The adapter will automatically communicate with Firebase to persist your
-  records as neccessary. Importantly, the adapter will also update the store
-  in realtime when changes are made to the Firebase by other clients or
-  otherwise.
-*/
+/**
+ * The Firebase adapter allows your store to communicate with the Firebase
+ * realtime service. To use the adapter in your app, extend DS.FirebaseAdapter
+ * and customize the endpoint to point to the Firebase URL where you want this
+ * data to be stored.
+ *
+ * The adapter will automatically communicate with Firebase to persist your
+ * records as neccessary. Importantly, the adapter will also update the store
+ * in realtime when changes are made to the Firebase by other clients or
+ * otherwise.
+ */
 export default DS.Adapter.extend(Ember.Evented, {
 
   defaultSerializer: '-firebase',
 
+
   /**
-    Endpoint paths can be customized by setting the Firebase property on the
-    adapter:
-
-    ```js
-    DS.FirebaseAdapter.extend({
-      firebase: new Firebase('https://<my-firebase>.firebaseio.com/')
-    });
-    ```
-
-    Requests for `App.Post` now target `https://<my-firebase>.firebaseio.com/posts`.
-
-    @property firebase
-    @type {Firebase}
-  */
-
-  init: function() {
+   * Endpoint paths can be customized by setting the Firebase property on the
+   * adapter:
+   *
+   * ```js
+   * DS.FirebaseAdapter.extend({
+   *   firebase: new Firebase('https://<my-firebase>.firebaseio.com/')
+   * });
+   * ```
+   *
+   * Requests for `App.Post` now target `https://<my-firebase>.firebaseio.com/posts`.
+   *
+   * @property firebase
+   * @type {Firebase}
+   * @constructor
+   */
+  init() {
     var firebase = this.get('firebase');
     if (!firebase || typeof firebase !== 'object') {
       throw new Error('Please set the `firebase` property on the adapter.');
@@ -68,21 +70,25 @@ export default DS.Adapter.extend(Ember.Evented, {
     this._queue = [];
   },
 
+
   /**
-    Uses push() to generate chronologically ordered unique IDs.
-  */
-  generateIdForRecord: function() {
+   * Uses push() to generate chronologically ordered unique IDs.
+   *
+   * @return {String}
+   */
+  generateIdForRecord() {
     return this._getKey(this._ref.push());
   },
 
-  /**
-    Use the Firebase DataSnapshot's key as the record id
 
-    @param {Object} snapshot - A Firebase snapshot
-    @param {Object} payload - The payload that will be pushed into the store
-    @return {Object} payload
-  */
-  _assignIdToPayload: function(snapshot) {
+  /**
+   * Use the Firebase DataSnapshot's key as the record id
+   *
+   * @param {Object} snapshot - A Firebase snapshot
+   * @param {Object} payload - The payload that will be pushed into the store
+   * @return {Object} payload
+   */
+  _assignIdToPayload(snapshot) {
     var payload = snapshot.val();
     if (payload !== null && typeof payload === 'object' && typeof payload.id === 'undefined') {
       payload.id = this._getKey(snapshot);
@@ -90,22 +96,22 @@ export default DS.Adapter.extend(Ember.Evented, {
     return payload;
   },
 
-  /**
-    Called by the store to retrieve the JSON for a given type and ID. The
-    method will return a promise which will resolve when the value is
-    successfully fetched from Firebase.
 
-    Additionally, from this point on, the object's value in the store will
-    also be automatically updated whenever the remote value changes.
-  */
-  findRecord: function(store, typeClass, id) {
-    var adapter = this;
+  /**
+   * Called by the store to retrieve the JSON for a given type and ID. The
+   * method will return a promise which will resolve when the value is
+   * successfully fetched from Firebase.
+   *
+   * Additionally, from this point on, the object's value in the store will
+   * also be automatically updated whenever the remote value changes.
+   */
+  findRecord(store, typeClass, id) {
     var ref = this._getCollectionRef(typeClass, id);
 
-    return new Promise(function(resolve, reject) {
-      ref.once('value', function(snapshot) {
-        var payload = adapter._assignIdToPayload(snapshot);
-        adapter._updateRecordCacheForType(typeClass, payload);
+    return new Promise((resolve, reject) => {
+      ref.once('value', (snapshot) => {
+        var payload = this._assignIdToPayload(snapshot);
+        this._updateRecordCacheForType(typeClass, payload);
         if (payload === null) {
           var error = new Error(`no record was found at ${ref.toString()}`);
               error.recordId = id;
@@ -121,51 +127,53 @@ export default DS.Adapter.extend(Ember.Evented, {
     }, `DS: FirebaseAdapter#findRecord ${typeClass.modelName} to ${ref.toString()}`);
   },
 
-  recordWasPushed: function(store, modelName, record) {
+
+  recordWasPushed(store, modelName, record) {
     if (!record.__listening) {
       var typeClass = store.modelFor(modelName);
       this.listenForChanges(store, typeClass, record);
     }
   },
 
-  recordWillUnload: function(store, record) {
+
+  recordWillUnload(store, record) {
     if (record.__listening) {
       this.stopListening(store, record.constructor, record);
     }
   },
 
-  recordWillDelete: function(store, record) {
-    var adapter = this;
 
-    record.eachRelationship(function (key, relationship) {
+  recordWillDelete(store, record) {
+    record.eachRelationship((key, relationship) => {
       if (relationship.kind === 'belongsTo') {
         var parentRecord = record.get(relationship.key);
         var inverseKey = record.inverseFor(relationship.key);
         if (inverseKey && parentRecord.get('id')) {
-          var parentRef = adapter._getCollectionRef(inverseKey.type, parentRecord.get('id'));
-          adapter._removeHasManyRecord(store, parentRef, inverseKey.name, record.id);
+          var parentRef = this._getCollectionRef(inverseKey.type, parentRecord.get('id'));
+          this._removeHasManyRecord(store, parentRef, inverseKey.name, record.id);
         }
       }
     });
   },
 
-  listenForChanges: function(store, typeClass, record) {
+
+  listenForChanges(store, typeClass, record) {
     // embedded records will get their changes from parent listeners
     if (!this.isRecordEmbedded(record)) {
       record.__listening = true;
-      var adapter = this;
       var ref = this._getCollectionRef(typeClass, record.id);
       var called = false;
-      ref.on('value', function FirebaseAdapter$changeListener(snapshot) {
+      ref.on('value', (snapshot) => {
         if (called) {
-          adapter._handleChildValue(store, typeClass, snapshot);
+          this._handleChildValue(store, typeClass, snapshot);
         }
         called = true;
       });
     }
   },
 
-  stopListening: function (store, typeClass, record) {
+
+  stopListening(store, typeClass, record) {
     if (record.__listening) {
       var ref = this._getCollectionRef(typeClass, record.id);
       ref.off('value');
@@ -173,57 +181,50 @@ export default DS.Adapter.extend(Ember.Evented, {
     }
   },
 
-  /**
-   findMany
-  */
-  findMany: undefined,
 
   /**
-    Called by the store to retrieve the JSON for all of the records for a
-    given type. The method will return a promise which will resolve when the
-    value is successfully fetched from Firebase.
-
-    Additionally, from this point on, any records of this type that are added,
-    removed or modified from Firebase will automatically be reflected in the
-    store.
-  */
-  findAll: function(store, typeClass) {
-    var adapter = this;
+   * Called by the store to retrieve the JSON for all of the records for a
+   * given type. The method will return a promise which will resolve when the
+   * value is successfully fetched from Firebase.
+   *
+   * Additionally, from this point on, any records of this type that are added,
+   * removed or modified from Firebase will automatically be reflected in the
+   * store.
+   */
+  findAll(store, typeClass) {
     var ref = this._getCollectionRef(typeClass);
 
-    return new Promise(function(resolve, reject) {
+    return new Promise((resolve, reject) => {
       // Listen for child events on the type
-      ref.once('value', function(snapshot) {
-        if (!adapter._findAllHasEventsForType(typeClass)) {
-          adapter._findAllAddEventListeners(store, typeClass, ref);
+      ref.once('value', (snapshot) => {
+        if (!this._findAllHasEventsForType(typeClass)) {
+          this._findAllAddEventListeners(store, typeClass, ref);
         }
         var results = [];
-        snapshot.forEach(function(childSnapshot) {
-          var payload = adapter._assignIdToPayload(childSnapshot);
-          adapter._updateRecordCacheForType(typeClass, payload);
+        snapshot.forEach((childSnapshot) => {
+          var payload = this._assignIdToPayload(childSnapshot);
+          this._updateRecordCacheForType(typeClass, payload);
           results.push(payload);
         });
         resolve(results);
-      }, function(error) {
-        reject(error);
-      });
+      }, (error) => reject(error) );
     }, `DS: FirebaseAdapter#findAll ${typeClass.modelName} to ${ref.toString()}`);
   },
 
-  query: function(store, typeClass, query, recordArray) {
-    var adapter = this;
+
+  query(store, typeClass, query, recordArray) {
     var ref = this._getCollectionRef(typeClass);
     var modelName = typeClass.modelName;
 
     ref = this.applyQueryToRef(ref, query);
 
-    ref.on('child_added', function(snapshot) {
+    ref.on('child_added', (snapshot) => {
       var record = store.peekRecord(modelName, snapshot.key());
 
       if (!record || !record.__listening) {
-        var payload = adapter._assignIdToPayload(snapshot);
+        var payload = this._assignIdToPayload(snapshot);
         var normalizedData = store.normalize(typeClass.modelName, payload);
-        adapter._updateRecordCacheForType(typeClass, payload);
+        this._updateRecordCacheForType(typeClass, payload);
         record = store.push(normalizedData);
       }
 
@@ -236,7 +237,7 @@ export default DS.Adapter.extend(Ember.Evented, {
     // value listener after a store.push. `child_moved` is
     // a much less common case because it relates to priority
 
-    ref.on('child_removed', function(snapshot) {
+    ref.on('child_removed', (snapshot) => {
       var record = store.peekRecord(modelName, snapshot.key());
       if (record) {
         recordArray.get('content').removeObject(record._internalModel);
@@ -251,26 +252,25 @@ export default DS.Adapter.extend(Ember.Evented, {
       ref.off('child_removed');
     };
 
-    return new Promise(function(resolve, reject) {
+    return new Promise((resolve, reject) => {
       // Listen for child events on the type
-      ref.once('value', function(snapshot) {
-        if (!adapter._findAllHasEventsForType(typeClass)) {
-          adapter._findAllAddEventListeners(store, typeClass, ref);
+      ref.once('value', (snapshot) => {
+        if (!this._findAllHasEventsForType(typeClass)) {
+          this._findAllAddEventListeners(store, typeClass, ref);
         }
         var results = [];
-        snapshot.forEach(function(childSnapshot) {
-          var payload = adapter._assignIdToPayload(childSnapshot);
-          adapter._updateRecordCacheForType(typeClass, payload);
+        snapshot.forEach((childSnapshot) => {
+          var payload = this._assignIdToPayload(childSnapshot);
+          this._updateRecordCacheForType(typeClass, payload);
           results.push(payload);
         });
         resolve(results);
-      }, function(error) {
-        reject(error);
-      });
+      }, (error) => reject(error) );
     }, `DS: FirebaseAdapter#query ${modelName} with ${query}`);
   },
 
-  applyQueryToRef: function (ref, query) {
+
+  applyQueryToRef(ref, query) {
 
     if (!query.orderBy) {
       query.orderBy = '_key';
@@ -295,39 +295,42 @@ export default DS.Adapter.extend(Ember.Evented, {
     return ref;
   },
 
-  /**
-    Keep track of what types `.findAll()` has been called for
-    so duplicate listeners aren't added
-  */
-  _findAllMapForType: undefined,
 
   /**
-    Determine if the current type is already listening for children events
-  */
-  _findAllHasEventsForType: function(typeClass) {
+   * Keep track of what types `.findAll()` has been called for
+   * so duplicate listeners aren't added
+   */
+  _findAllMapForType: undefined,
+
+
+  /**
+   * Determine if the current type is already listening for children events
+   */
+  _findAllHasEventsForType(typeClass) {
     return !Ember.isNone(this._findAllMapForType[typeClass.modelName]);
   },
 
+
   /**
-    After `.findAll()` is called on a modelName, continue to listen for
-    `child_added`, `child_removed`, and `child_changed`
-  */
-  _findAllAddEventListeners: function(store, typeClass, ref) {
+   * After `.findAll()` is called on a modelName, continue to listen for
+   * `child_added`, `child_removed`, and `child_changed`
+   */
+  _findAllAddEventListeners(store, typeClass, ref) {
     var modelName = typeClass.modelName;
     this._findAllMapForType[modelName] = true;
 
-    var adapter = this;
-    ref.on('child_added', function(snapshot) {
-      if (!store.hasRecordForId(modelName, adapter._getKey(snapshot))) {
-        adapter._handleChildValue(store, typeClass, snapshot);
+    ref.on('child_added', (snapshot) => {
+      if (!store.hasRecordForId(modelName, this._getKey(snapshot))) {
+        this._handleChildValue(store, typeClass, snapshot);
       }
     });
   },
 
+
   /**
-    Push a new child record into the store
-  */
-  _handleChildValue: function(store, typeClass, snapshot) {
+   * Push a new child record into the store
+   */
+  _handleChildValue(store, typeClass, snapshot) {
     // No idea why we need this, we are already turning off the callback by
     // calling ref.off in recordWillUnload. Something is fishy here
     if (store.isDestroying) {
@@ -353,34 +356,33 @@ export default DS.Adapter.extend(Ember.Evented, {
     }
   },
 
+
   /**
-    `createRecord` is an alias for `updateRecord` because calling \
-    `ref.set()` would wipe out any existing relationships
-  */
-  createRecord: function(store, typeClass, snapshot) {
-    var adapter = this;
-    return this.updateRecord(store, typeClass, snapshot).then(function() {
-      adapter.listenForChanges(store, typeClass, snapshot.record);
+   * `createRecord` is an alias for `updateRecord` because calling \
+   * `ref.set()` would wipe out any existing relationships
+   */
+  createRecord(store, typeClass, snapshot) {
+    return this.updateRecord(store, typeClass, snapshot).then(() => {
+      this.listenForChanges(store, typeClass, snapshot.record);
     });
   },
 
+
   /**
-    Called by the store when a record is created/updated via the `save`
-    method on a model record instance.
-
-    The `updateRecord` method serializes the record and performs an `update()`
-    at the the Firebase location and a `.set()` at any relationship locations
-    The method will return a promise which will be resolved when the data and
-    any relationships have been successfully saved to Firebase.
-
-    We take an optional record reference, in order for this method to be usable
-    for saving nested records as well.
-
-  */
-  updateRecord: function(store, typeClass, snapshot) {
-    var adapter = this;
+   * Called by the store when a record is created/updated via the `save`
+   * method on a model record instance.
+   *
+   * The `updateRecord` method serializes the record and performs an `update()`
+   * at the the Firebase location and a `.set()` at any relationship locations
+   * The method will return a promise which will be resolved when the data and
+   * any relationships have been successfully saved to Firebase.
+   *
+   * We take an optional record reference, in order for this method to be usable
+   * for saving nested records as well.
+   */
+  updateRecord(store, typeClass, snapshot) {
     var recordRef = this._getAbsoluteRef(snapshot.record);
-    var recordCache = adapter._getRecordCache(typeClass, snapshot.id);
+    var recordCache = this._getRecordCache(typeClass, snapshot.id);
 
     var pathPieces = recordRef.path.toString().split('/');
     var lastPiece = pathPieces[pathPieces.length-1];
@@ -388,20 +390,20 @@ export default DS.Adapter.extend(Ember.Evented, {
       includeId: (lastPiece !== snapshot.id) // record has no firebase `key` in path
     });
 
-    return new Promise(function(resolve, reject) {
+    return new Promise((resolve, reject) => {
       var savedRelationships = Ember.A();
-      snapshot.record.eachRelationship(function(key, relationship) {
+      snapshot.record.eachRelationship((key, relationship) => {
         var save;
         if (relationship.kind === 'hasMany') {
           if (serializedRecord[key]) {
-            save = adapter._saveHasManyRelationship(store, typeClass, relationship, serializedRecord[key], recordRef, recordCache);
+            save = this._saveHasManyRelationship(store, typeClass, relationship, serializedRecord[key], recordRef, recordCache);
             savedRelationships.push(save);
             // Remove the relationship from the serializedRecord because otherwise we would clobber the entire hasMany
             delete serializedRecord[key];
           }
         } else {
-          if (adapter.isRelationshipEmbedded(store, typeClass.modelName, relationship) && serializedRecord[key]) {
-            save = adapter._saveEmbeddedBelongsToRecord(store, typeClass, relationship, serializedRecord[key], recordRef);
+          if (this.isRelationshipEmbedded(store, typeClass.modelName, relationship) && serializedRecord[key]) {
+            save = this._saveEmbeddedBelongsToRecord(store, typeClass, relationship, serializedRecord[key], recordRef);
             savedRelationships.push(save);
             delete serializedRecord[key];
           }
@@ -409,9 +411,9 @@ export default DS.Adapter.extend(Ember.Evented, {
       });
 
       var relationshipsPromise = Ember.RSVP.allSettled(savedRelationships);
-      var recordPromise = adapter._updateRecord(recordRef, serializedRecord);
+      var recordPromise = this._updateRecord(recordRef, serializedRecord);
 
-      Ember.RSVP.hashSettled({relationships: relationshipsPromise, record: recordPromise}).then(function(promises) {
+      Ember.RSVP.hashSettled({relationships: relationshipsPromise, record: recordPromise}).then((promises) => {
         var rejected = Ember.A(promises.relationships.value).filterBy('state', 'rejected');
         if (promises.record.state === 'rejected') {
           rejected.push(promises.record);
@@ -428,50 +430,56 @@ export default DS.Adapter.extend(Ember.Evented, {
     }, `DS: FirebaseAdapter#updateRecord ${typeClass} to ${recordRef.toString()}`);
   },
 
-  //Just update the record itself without caring for the relationships
-  _updateRecord: function(recordRef, serializedRecord) {
+
+  /**
+   * Update a single record without caring for the relationships
+   * @param  {Firebase} recordRef
+   * @param  {Object} serializedRecord
+   * @return {Promise}
+   */
+  _updateRecord(recordRef, serializedRecord) {
     return toPromise(recordRef.update, recordRef, [serializedRecord]);
   },
 
+
   /**
-    Call _saveHasManyRelationshipRecord on each record in the relationship
-    and then resolve once they have all settled
-  */
-  _saveHasManyRelationship: function(store, typeClass, relationship, ids, recordRef, recordCache) {
+   * Call _saveHasManyRelationshipRecord on each record in the relationship
+   * and then resolve once they have all settled
+   */
+  _saveHasManyRelationship(store, typeClass, relationship, ids, recordRef, recordCache) {
     if (!Ember.isArray(ids)) {
       throw new Error('hasMany relationships must must be an array');
     }
-    var adapter = this;
     var idsCache = Ember.A(recordCache[relationship.key]);
     var dirtyRecords = [];
 
     // Added
-    var addedRecords = filter(ids, function(id) {
+    var addedRecords = filter(ids, (id) => {
       return !idsCache.contains(id);
     });
 
     // Dirty
-    dirtyRecords = filter(ids, function(id) {
+    dirtyRecords = filter(ids, (id) => {
       var relatedModelName = relationship.type;
       return store.hasRecordForId(relatedModelName, id) && store.peekRecord(relatedModelName, id).get('hasDirtyAttributes') === true;
     });
 
-    dirtyRecords = map(uniq(dirtyRecords.concat(addedRecords)), function(id) {
-      return adapter._saveHasManyRecord(store, typeClass, relationship, recordRef, id);
+    dirtyRecords = map(uniq(dirtyRecords.concat(addedRecords)), (id) => {
+      return this._saveHasManyRecord(store, typeClass, relationship, recordRef, id);
     });
 
     // Removed
-    var removedRecords = filter(idsCache, function(id) {
+    var removedRecords = filter(idsCache, (id) => {
       return !includes(ids, id);
     });
 
-    removedRecords = map(removedRecords, function(id) {
-      return adapter._removeHasManyRecord(store, recordRef, relationship.key, id);
+    removedRecords = map(removedRecords, (id) => {
+      return this._removeHasManyRecord(store, recordRef, relationship.key, id);
     });
     // Combine all the saved records
     var savedRecords = dirtyRecords.concat(removedRecords);
     // Wait for all the updates to finish
-    return Ember.RSVP.allSettled(savedRecords).then(function(savedRecords) {
+    return Ember.RSVP.allSettled(savedRecords).then((savedRecords) => {
       var rejected = Ember.A(Ember.A(savedRecords).filterBy('state', 'rejected'));
       if (rejected.get('length') === 0) {
         // Update the cache
@@ -486,15 +494,16 @@ export default DS.Adapter.extend(Ember.Evented, {
     });
   },
 
-  /**
-    If the relationship is `async: true`, create a child ref
-    named with the record id and set the value to true
 
-    If the relationship is `embedded: true`, create a child ref
-    named with the record id and update the value to the serialized
-    version of the record
-  */
-  _saveHasManyRecord: function(store, typeClass, relationship, parentRef, id) {
+  /**
+   * If the relationship is `async: true`, create a child ref
+   * named with the record id and set the value to true
+
+   * If the relationship is `embedded: true`, create a child ref
+   * named with the record id and update the value to the serialized
+   * version of the record
+   */
+  _saveHasManyRecord(store, typeClass, relationship, parentRef, id) {
     var ref = this._getRelationshipRef(parentRef, relationship.key, id);
     var record = store.peekRecord(relationship.type, id);
     var isEmbedded = this.isRelationshipEmbedded(store, typeClass.modelName, relationship);
@@ -504,6 +513,7 @@ export default DS.Adapter.extend(Ember.Evented, {
 
     return toPromise(ref.set, ref,  [true]);
   },
+
 
   /**
    * Determine from the serializer if the relationship is embedded via the
@@ -515,6 +525,7 @@ export default DS.Adapter.extend(Ember.Evented, {
     var serializer = store.serializerFor(modelName);
     return serializer.hasDeserializeRecordsOption(relationship.key);
   },
+
 
   /**
    * Determine from if the record is embedded via implicit relationships.
@@ -531,20 +542,22 @@ export default DS.Adapter.extend(Ember.Evented, {
     return !!found;
   },
 
+
   /**
-    Remove a relationship
-  */
-  _removeHasManyRecord: function(store, parentRef, key, id) {
+   * Remove a relationship
+   */
+  _removeHasManyRecord(store, parentRef, key, id) {
     var ref = this._getRelationshipRef(parentRef, key, id);
     return toPromise(ref.remove, ref, [], ref.toString());
   },
+
 
   /**
    * Save an embedded belongsTo record and set its internal firebase ref
    *
    * @return {Promise<DS.Model>}
    */
-  _saveEmbeddedBelongsToRecord: function(store, typeClass, relationship, id, parentRef) {
+  _saveEmbeddedBelongsToRecord(store, typeClass, relationship, id, parentRef) {
     var record = store.peekRecord(relationship.type, id);
     if (record) {
       return record.save();
@@ -552,26 +565,29 @@ export default DS.Adapter.extend(Ember.Evented, {
     return Ember.RSVP.Promise.reject(new Error(`Unable to find record with id ${id} from embedded relationship: ${JSON.stringify(relationship)}`));
   },
 
+
   /**
-    Called by the store when a record is deleted.
-  */
-  deleteRecord: function(store, typeClass, snapshot) {
+   * Called by the store when a record is deleted.
+   */
+  deleteRecord(store, typeClass, snapshot) {
     var ref = this._getAbsoluteRef(snapshot.record);
     return toPromise(ref.remove, ref);
   },
 
+
   /**
-    Determines a path fo a given type
-  */
-  pathForType: function(modelName) {
+   * Determines a path fo a given type
+   */
+  pathForType(modelName) {
     var camelized = Ember.String.camelize(modelName);
     return Ember.String.pluralize(camelized);
   },
 
+
   /**
-    Return a Firebase reference for a given modelName and optional ID.
-  */
-  _getCollectionRef: function(typeClass, id) {
+   * Return a Firebase reference for a given modelName and optional ID.
+   */
+  _getCollectionRef(typeClass, id) {
     var ref = this._ref;
     if (typeClass) {
       ref = ref.child(this.pathForType(typeClass.modelName));
@@ -582,13 +598,14 @@ export default DS.Adapter.extend(Ember.Evented, {
     return ref;
   },
 
+
   /**
    * Returns a Firebase reference for a record taking into account if the record is embedded
    *
    * @param  {DS.Model} record
    * @return {Firebase}
    */
-  _getAbsoluteRef: function(record) {
+  _getAbsoluteRef(record) {
     if (record._internalModel) {
       record = record._internalModel;
     }
@@ -607,6 +624,7 @@ export default DS.Adapter.extend(Ember.Evented, {
 
     return this._getCollectionRef(record.type, record.id);
   },
+
 
   /**
    * Returns the parent record and relationship where any embedding is detected
@@ -635,29 +653,33 @@ export default DS.Adapter.extend(Ember.Evented, {
     }
   },
 
+
   /**
-    Return a Firebase reference based on a relationship key and record id
-  */
-  _getRelationshipRef: function(ref, key, id) {
+   * Return a Firebase reference based on a relationship key and record id
+   */
+  _getRelationshipRef(ref, key, id) {
     return ref.child(key).child(id);
   },
 
-  /**
-    The amount of time (ms) before the _queue is flushed
-  */
-  _queueFlushDelay: (1000/60), // 60fps
 
   /**
-    Called after the first item is pushed into the _queue
-  */
-  _queueScheduleFlush: function() {
+   * The amount of time (ms) before the _queue is flushed
+   */
+  _queueFlushDelay: (1000/60), // 60fps
+
+
+  /**
+   * Called after the first item is pushed into the _queue
+   */
+  _queueScheduleFlush() {
     Ember.run.later(this, this._queueFlush, this._queueFlushDelay);
   },
 
+
   /**
-    Call each function in the _queue and the reset the _queue
-  */
-  _queueFlush: function() {
+   * Call each function in the _queue and the reset the _queue
+   */
+  _queueFlush() {
     forEach(this._queue, function FirebaseAdapter$flushQueueItem(queueItem) {
       var fn = queueItem[0];
       var args = queueItem[1];
@@ -666,11 +688,12 @@ export default DS.Adapter.extend(Ember.Evented, {
     this._queue.length = 0;
   },
 
+
   /**
-    Push a new function into the _queue and then schedule a
-    flush if the item is the first to be pushed
-  */
-  _enqueue: function(callback, args) {
+   * Push a new function into the _queue and then schedule a
+   * flush if the item is the first to be pushed
+   */
+  _enqueue(callback, args) {
     //Only do the queueing if we scheduled a delay
     if (this._queueFlushDelay) {
       var length = this._queue.push([callback, args]);
@@ -682,21 +705,23 @@ export default DS.Adapter.extend(Ember.Evented, {
     }
   },
 
-  /**
-    A cache of hasMany relationships that can be used to
-    diff against new relationships when a model is saved
-  */
-  _recordCacheForType: undefined,
 
   /**
-    _updateHasManyCacheForType
-  */
-  _updateRecordCacheForType: function(typeClass, payload) {
+   * A cache of hasMany relationships that can be used to
+   * diff against new relationships when a model is saved
+   */
+  _recordCacheForType: undefined,
+
+
+  /**
+   * _updateHasManyCacheForType
+   */
+  _updateRecordCacheForType(typeClass, payload) {
     if (!payload) { return; }
     var id = payload.id;
     var cache = this._getRecordCache(typeClass, id);
     // Only cache relationships for now
-    typeClass.eachRelationship(function(key, relationship) {
+    typeClass.eachRelationship((key, relationship) => {
       if (relationship.kind === 'hasMany') {
         var ids = payload[key];
         cache[key] = !Ember.isNone(ids) ? Ember.A(Object.keys(ids)) : Ember.A();
@@ -704,16 +729,18 @@ export default DS.Adapter.extend(Ember.Evented, {
     });
   },
 
+
   /**
-    Get or create the cache for a record
+   * Get or create the cache for a record
    */
-  _getRecordCache: function (typeClass, id) {
+  _getRecordCache(typeClass, id) {
     var modelName = typeClass.modelName;
     var cache = this._recordCacheForType;
     cache[modelName] = cache[modelName] || {};
     cache[modelName][id] = cache[modelName][id] || {};
     return cache[modelName][id];
   },
+
 
   /**
    * A utility for retrieving the key name of a Firebase ref or
@@ -722,14 +749,15 @@ export default DS.Adapter.extend(Ember.Evented, {
    * support for Firebase 1.x.x is dropped in EmberFire, this
    * helper can be removed.
    */
-  _getKey: function(refOrSnapshot) {
+  _getKey(refOrSnapshot) {
     return (typeof refOrSnapshot.key === 'function') ? refOrSnapshot.key() : refOrSnapshot.name();
   },
+
 
   /**
    * We don't need background reloading, because firebase!
    */
-  shouldBackgroundReloadRecord: function() {
+  shouldBackgroundReloadRecord() {
     return false;
   }
 });

--- a/addon/initializers/emberfire.js
+++ b/addon/initializers/emberfire.js
@@ -18,7 +18,7 @@ if (Ember.libraries) {
 export default {
   name: 'emberfire',
   before: 'ember-data',
-  initialize: function () {
+  initialize() {
 
     // To support Ember versions below 2.1.0 as well.
     // See http://emberjs.com/deprecations/v2.x/#toc_initializer-arity
@@ -31,7 +31,8 @@ export default {
     if (!DS.Store.prototype._emberfirePatched) {
       DS.Store.reopen({
         _emberfirePatched: true,
-        push: function() {
+
+        push() {
           var result = this._super.apply(this, arguments);
           var records = result;
 
@@ -50,14 +51,14 @@ export default {
           return result;
         },
 
-        recordWillUnload: function(record) {
+        recordWillUnload(record) {
           var adapter = this.adapterFor(record.constructor.modelName);
           if (adapter.recordWillUnload) {
             adapter.recordWillUnload(this, record);
           }
         },
 
-        recordWillDelete: function (record) {
+        recordWillDelete(record) {
           var adapter = this.adapterFor(record.constructor.modelName);
           if (adapter.recordWillDelete) {
             adapter.recordWillDelete(this, record);
@@ -69,16 +70,18 @@ export default {
     if (!DS.Model.prototype._emberfirePatched) {
       DS.Model.reopen({
         _emberfirePatched: true,
-        unloadRecord: function() {
+
+        unloadRecord() {
           this.store.recordWillUnload(this);
           return this._super();
         },
-        deleteRecord: function () {
+
+        deleteRecord() {
           this.store.recordWillDelete(this);
           this._super();
         },
 
-        ref: function () {
+        ref() {
           var adapter = this.store.adapterFor(this.constructor.modelName);
           if (adapter._getAbsoluteRef) {
             return adapter._getAbsoluteRef(this);
@@ -90,7 +93,8 @@ export default {
     if (!DS.AdapterPopulatedRecordArray.prototype._emberfirePatched) {
       DS.AdapterPopulatedRecordArray.reopen({
         _emberfirePatched: true,
-        willDestroy: function() {
+
+        willDestroy() {
           if (this.__firebaseCleanup) {
             this.__firebaseCleanup();
           }

--- a/addon/serializers/firebase.js
+++ b/addon/serializers/firebase.js
@@ -9,17 +9,18 @@ import assign from 'lodash/object/assign';
 export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
   isNewSerializerAPI: true,
 
+
   /**
    * Firebase does not send null values, it omits the key altogether. This nullifies omitted
    * properties so that property deletions sync correctly.
    *
    * @override
    */
-  extractAttributes: function (modelClass, resourceHash) {
+  extractAttributes(modelClass, resourceHash) {
     var attributes = this._super(modelClass, resourceHash);
 
     // nullify omitted attributes
-    modelClass.eachAttribute(function (key) {
+    modelClass.eachAttribute((key) => {
       if (!attributes.hasOwnProperty(key)) {
         attributes[key] = null;
       }
@@ -27,6 +28,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
 
     return attributes;
   },
+
 
   /**
    * @override
@@ -36,6 +38,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
 
     return this._super(modelClass, payload);
   },
+
 
   /**
    * Normalizes `hasMany` relationship structure before passing
@@ -96,7 +99,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
           // embedded
           if (this.hasDeserializeRecordsOption(key)) {
             if (typeof payload[key] === 'object' && !Ember.isArray(payload[key])) {
-              payload[key] = Object.keys(payload[key]).map(function(id) {
+              payload[key] = Object.keys(payload[key]).map((id) => {
                 return assign({ id: id }, payload[key][id]);
               });
             } else if (Ember.isArray(payload[key])) {
@@ -136,6 +139,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
       }
     });
   },
+
 
   /**
    * Coerce arrays back into relationship arrays. When numeric ids are used
@@ -184,6 +188,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
     return result;
   },
 
+
   /**
    * Fix embedded array ids.
    *
@@ -228,6 +233,7 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
     return result;
   },
 
+
   /**
    * Even when records are embedded, bypass EmbeddedRecordsMixin
    * and invoke JSONSerializer's method which serializes to ids only.
@@ -241,22 +247,24 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
    *
    * @override
    */
-  serializeHasMany: function (snapshot, json, relationship) {
+  serializeHasMany(snapshot, json, relationship) {
     DS.JSONSerializer.prototype.serializeHasMany.call(this, snapshot, json, relationship);
   },
+
 
   /**
    * @see #serializeHasMany
    * @override
    */
-  serializeBelongsTo: function (snapshot, json, relationship) {
+  serializeBelongsTo(snapshot, json, relationship) {
     DS.JSONSerializer.prototype.serializeBelongsTo.call(this, snapshot, json, relationship);
   },
+
 
   /**
    * @override
    */
-  _shouldSerializeHasMany: function (snapshot, key, relationship) {
+  _shouldSerializeHasMany(snapshot, key, relationship) {
     return this._canSerialize(key);
   }
 });

--- a/addon/torii-adapters/firebase.js
+++ b/addon/torii-adapters/firebase.js
@@ -1,8 +1,11 @@
 import Ember from 'ember';
 
 export default Ember.Object.extend({
+
+
   /**
    * Extacts session information from authentication response
+   *
    * @param {object} authentication - hash containing response payload
    * @return {Promise}
    */
@@ -13,13 +16,16 @@ export default Ember.Object.extend({
       currentUser: authentication[authentication.provider]
     });
   },
+
+
   /**
    * Restore existing authenticated session
+   *
    * @return {Promise}
    */
   fetch() {
     let firebase = this.get('firebase');
-    return new Ember.RSVP.Promise((resolve, reject)=>{
+    return new Ember.RSVP.Promise((resolve, reject) => {
       let auth = firebase.getAuth();
       if (!auth) {
         reject("No session available");
@@ -28,8 +34,11 @@ export default Ember.Object.extend({
       }
     }, "Firebase Torii Adapter#fetch Firebase session");
   },
+
+
   /**
    * Close existing authenticated session
+   *
    * @return {Promise}
    */
   close() {


### PR DESCRIPTION
- Uses arrow functions instead of reassigning `this`
- Cleans up method docs to use consistent style and 2 spaces above