### PR TITLE
Log error in listenForChanges.

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -194,6 +194,8 @@ export default DS.Adapter.extend(Waitable, {
           });
         }
         called = true;
+      }, (error) => {
+        Ember.Logger.error(error);
       });
     }
   },


### PR DESCRIPTION
I was running into some errors in an app I'm working on that were difficult to track down until I realized that the value read listener for records was failing due to some of our Firebase security rules, and Emberfire wasn't logging them.