### PR TITLE
Turn off listener on delete record.

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -596,6 +596,7 @@ export default DS.Adapter.extend(Waitable, {
    */
   deleteRecord(store, typeClass, snapshot) {
     var ref = this._getAbsoluteRef(snapshot.record);
+    ref.off('value');
     return toPromise(ref.remove, ref);
   },
 


### PR DESCRIPTION
One of the errors alluded to in #358 was a failure in the value read listener around the time of a delete. The change in this PR prevents that error for me. Though, I'm not sure I've implemented it in the right place - e.g. how `deleteRecord` relates to `recordWillUnload` which already calls `stopListening` which does something similar.