### PR TITLE
Fix Torii provider option.

### DIFF
--- a/addon/torii-providers/firebase.js
+++ b/addon/torii-providers/firebase.js
@@ -41,9 +41,9 @@ export default Ember.Object.extend(Waitable, {
         let providerSettings = options.settings || {};
         if (options.redirect === true) {
           // promise will never resolve unless there is an error
-          return this._toPromise(ref, 'authWithOAuthRedirect', options.provider, providerSettings);
+          return this._toPromise(ref, 'authWithOAuthRedirect', provider, providerSettings);
         }
-        return this._toPromise(ref, 'authWithOAuthPopup', options.provider, providerSettings);
+        return this._toPromise(ref, 'authWithOAuthPopup', provider, providerSettings);
     }
   },
 


### PR DESCRIPTION
Using the Firebase OAuth Torii provider included in Emberfire, it seems `options.provider` isn't always defined, in the case of `options.authWith`, but the `provider` variable picks whichever is defined a few lines above, so we need to use that instead. Otherwise we get this error:
```
Error: Firebase.authWithOAuthPopup failed: First argument must be a valid string.(…)
```
