### PR TITLE
multipath save 

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -360,7 +360,6 @@ export default DS.Adapter.extend(Waitable, {
       return;
     }
 		// reset cache
-
     var value = snapshot.val();
     if (value === null) {
       var id = this._getKey(snapshot);
@@ -372,7 +371,6 @@ export default DS.Adapter.extend(Waitable, {
       }
     } else {
       var payload = this._assignIdToPayload(snapshot);
-			this._removeFromPreviousCache(payload.id);
       this._enqueue(function FirebaseAdapter$enqueueStorePush() {
         if (!store.isDestroying) {
           var normalizedData = store.normalize(typeClass.modelName, payload);
@@ -450,15 +448,10 @@ export default DS.Adapter.extend(Waitable, {
       includeId: (lastPiece !== snapshot.id) // record has no firebase `key` in path
     });
 
-		console.log("BEFORE ======> ");
-    console.log(JSON.stringify(serializedRecord, null, '\t'));
     this._recurseGenerateMultiPathUpdate(serializedRecord);
 		if (previous) {
-			console.log("what !");
 			this._recurseGenerateMultiPathDelete(serializedRecord, previous);
 		}
-		console.log("AFTER ======> ");
-    console.log(JSON.stringify(serializedRecord, null, '\t'));
 		this._setPreviousCache(snapshot.id, serializedRecord);
 
     return this._updateRecord(recordRef, serializedRecord).then(() => {

--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -378,13 +378,18 @@ export default DS.Adapter.extend(Waitable, {
    */
   _recurseGenerateMultiPathUpdate(serializedRecord) {
     for (var key in serializedRecord) {
-      if (serializedRecord.hasOwnProperty(key)) {
+      if (serializedRecord.hasOwnProperty(key) && key !== "_") {
         var data = serializedRecord[key];
-        if (!Ember.isNone(data) && (typeof data === "object")) {
+        if ((typeof data === "function")) {
+          delete serializedRecord[key];
+        }
+        else if (!Ember.isNone(data) && (typeof data === "object")) {
           for (var prop in data) {
-            var sub = key + '/' + prop;
-            this._recurseGenerateMultiPathUpdate(data[prop]);
-            serializedRecord[sub] = data[prop];
+            if (data.hasOwnProperty(prop)) {
+              var sub = key + '/' + prop;
+              this._recurseGenerateMultiPathUpdate(data[prop]);
+              serializedRecord[sub] = data[prop];
+            }
           }
           delete serializedRecord[key];
         }

--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -378,20 +378,19 @@ export default DS.Adapter.extend(Waitable, {
    */
   _recurseGenerateMultiPathUpdate(serializedRecord) {
     for (var key in serializedRecord) {
-			if (serializedRecord.hasOwnProperty(key)) {
-	      var data = serializedRecord[key];
-	      if (!Ember.isNone(data) && (typeof data === "object")) {
-	        for (var prop in data) {
-							var sub = key + '/' + prop;
-		          this._recurseGenerateMultiPathUpdate(data[prop]);
-		          serializedRecord[sub] = data[prop];
-						}
-	        }
-	        delete serializedRecord[key];
-	      }
-			} else {
-				delete serializedRecord[key];
-			}
+      if (serializedRecord.hasOwnProperty(key)) {
+        var data = serializedRecord[key];
+        if (!Ember.isNone(data) && (typeof data === "object")) {
+          for (var prop in data) {
+            var sub = key + '/' + prop;
+            this._recurseGenerateMultiPathUpdate(data[prop]);
+            serializedRecord[sub] = data[prop];
+          }
+          delete serializedRecord[key];
+        }
+      } else {
+        delete serializedRecord[key];
+      }
     }
   },
 
@@ -413,11 +412,11 @@ export default DS.Adapter.extend(Waitable, {
     var serializedRecord = snapshot.serialize({
       includeId: (lastPiece !== snapshot.id) // record has no firebase `key` in path
     });
-		console.log("BEFORE ======> ");
-		console.log(serializedRecord);
+    console.log("BEFORE ======> ");
+    console.log(serializedRecord);
     this._recurseGenerateMultiPathUpdate(serializedRecord);
-		console.log("AFTER ======> ");
-		console.log(serializedRecord);
+    console.log("AFTER ======> ");
+    console.log(serializedRecord);
     return this._updateRecord(recordRef, serializedRecord).then(() => {
       return this._cleanEmbeddedChildren(store, typeClass, snapshot);
     }).then(() => {

--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -180,8 +180,10 @@ export default DS.Adapter.extend(Waitable, {
         } else {
 					Ember.run( () => {
 						var payload = this._assignIdToPayload(snapshot);
-						this._recurseGenerateMultiPathUpdate(payload, '', payload);
-						this._setPreviousCache(payload.id, payload);
+						if (payload) {
+							this._recurseGenerateMultiPathUpdate(payload, '', payload);
+							this._setPreviousCache(payload.id, payload);
+						}
 					});
 				}
 
@@ -379,9 +381,11 @@ export default DS.Adapter.extend(Waitable, {
     } else {
       var payload = this._assignIdToPayload(snapshot);
 			// FIXME: deep object copy, definitly not the best way of doing ...
-			var payloadCache = JSON.parse(JSON.stringify(payload));
-			this._recurseGenerateMultiPathUpdate(payloadCache, '', payloadCache);
-			this._setPreviousCache(payloadCache.id, payloadCache);
+			if (payload) {
+				var payloadCache = JSON.parse(JSON.stringify(payload));
+				this._recurseGenerateMultiPathUpdate(payloadCache, '', payloadCache);
+				this._setPreviousCache(payloadCache.id, payloadCache);				
+			}
       this._enqueue(function FirebaseAdapter$enqueueStorePush() {
         if (!store.isDestroying) {
 					var normalizedData = store.normalize(typeClass.modelName, payload);

--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -378,15 +378,20 @@ export default DS.Adapter.extend(Waitable, {
    */
   _recurseGenerateMultiPathUpdate(serializedRecord) {
     for (var key in serializedRecord) {
-      var data = serializedRecord[key];
-      if (!Ember.isNone(data) && (typeof data === "object")) {
-        for (var prop in data) {
-          var sub = key + '/' + prop;
-          this._recurseGenerateMultiPathUpdate(data[prop]);
-          serializedRecord[sub] = data[prop];
-        }
-        delete serializedRecord[key];
-      }
+			if (serializedRecord.hasOwnProperty(key)) {
+	      var data = serializedRecord[key];
+	      if (!Ember.isNone(data) && (typeof data === "object")) {
+	        for (var prop in data) {
+							var sub = key + '/' + prop;
+		          this._recurseGenerateMultiPathUpdate(data[prop]);
+		          serializedRecord[sub] = data[prop];
+						}
+	        }
+	        delete serializedRecord[key];
+	      }
+			} else {
+				delete serializedRecord[key];
+			}
     }
   },
 
@@ -409,10 +414,10 @@ export default DS.Adapter.extend(Waitable, {
       includeId: (lastPiece !== snapshot.id) // record has no firebase `key` in path
     });
 		console.log("BEFORE ======> ");
-		console.log(JSON.stringify(serializedRecord));
+		console.log(serializedRecord);
     this._recurseGenerateMultiPathUpdate(serializedRecord);
 		console.log("AFTER ======> ");
-		console.log(JSON.stringify(serializedRecord));
+		console.log(serializedRecord);
     return this._updateRecord(recordRef, serializedRecord).then(() => {
       return this._cleanEmbeddedChildren(store, typeClass, snapshot);
     }).then(() => {


### PR DESCRIPTION
Test are not passing, because I think they are not valid in the way we want this thing to work : 

To destroy a link you need to set null to it, and some of the tests are just emptying the relation object.

For example :

``` javascript
// comments is a hasMany
comments:{id1:true,id2:true}
// test want to reset comment and check if it was emptied
comments:{}
```

Cannot work, at it will either require comment to be set to null : 

``` javascript
comments:null
```

Or all elements to be set to null:

``` javascript
comments:{id1:null,id2:null}
```

The other problem, which I'm not sure I can trace back ( lacking time ) is this error :

> Error: Firebase.update failed: First argument  contains an invalid key (children/- KAJmTkzssePlP9HbfSs) in property 'blogs.tests.adapter.updaterecord.embedded.treeNodes.-KAJmTkyP_fKXLpXTw47.children.-KAJmTkyP_fKXLpXTw48'.  Keys must be non-empty strings and can't contain ".", "#", "$", "/", "[", or "]" (http://localhost:7357/assets/vendor.js:71731)

I think it is "internal" checking. 

As an example here is what the multipath code generate from the usual serializedRecord :

``` javascript
// BEFORE ======> 
{
    "label": "Parent Node",
    "created": null,
    "children": {
        "-KAJmTkyP_fKXLpXTw48": {
            "id": "-KAJmTkyP_fKXLpXTw48",
            "label": "Child Node",
            "created": null,
            "children": {
                "-KAJmTkzssePlP9HbfSs": {
                    "id": "-KAJmTkzssePlP9HbfSs",
                    "label": "Child Sub Node",
                    "created": null,
                    "children": null,
                    "config": null
                }
            },
            "config": null
        }
    },
    "config": null
}
// AFTER ======> 
{
    "label": "Parent Node",
    "created": null,
    "config": null,
    "children/-KAJmTkyP_fKXLpXTw48": {
        "id": "-KAJmTkyP_fKXLpXTw48",
        "label": "Child Node",
        "created": null,
        "config": null,
        "children/-KAJmTkzssePlP9HbfSs": {
            "id": "-KAJmTkzssePlP9HbfSs",
            "label": "Child Sub Node",
            "created": null,
            "children": null,
            "config": null
        }
    }
}
```
