### PR TITLE
Update torii

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "gulp-uglify": "1.2.0",
     "gulp-util": "3.0.6",
     "lodash": "3.10.0",
-    "torii": "0.6.1",
+    "torii": "0.8.0-beta.1",
     "vinyl-buffer": "1.0.0",
     "vinyl-source-stream": "1.1.0"
   }


### PR DESCRIPTION
Updating Torii fixes some issues introduced with Ember 2.3.0 and gets rid of the `container` deprecation :palm_tree: 

- https://github.com/Vestorly/torii/issues/266
- https://github.com/Vestorly/torii/releases/tag/v0.8.0-beta.1

I've only tested it with our own Emberfire 1.6.6 application where it works fine but I see a failing test. Would be nice to get this update in.