### PR TITLE
Fixes #396. Use updated ember lookup syntax.

### DIFF
--- a/addon/services/firebase-app.js
+++ b/addon/services/firebase-app.js
@@ -1,10 +1,13 @@
 import firebase from 'firebase';
+import Ember from 'ember';
+
+const { getOwner } = Ember;
 
 export const DEFAULT_NAME = '[EmberFire default app]';
 
 export default {
   create(application) {
-    const config = application.container.lookupFactory('config:environment');
+    const config = getOwner(application)._lookupFactory('config:environment');
     if (!config || typeof config.firebase !== 'object') {
       throw new Error('Please set the `firebase` property in your environment config.');
     }

--- a/addon/services/firebase.js
+++ b/addon/services/firebase.js
@@ -1,10 +1,13 @@
 import firebase from 'firebase';
+import Ember from 'ember';
+
+const { getOwner } = Ember;
 
 export const DEFAULT_NAME = '[EmberFire default app]';
 
 export default {
   create(application) {
-    const config = application.container.lookupFactory('config:environment');
+    const config = getOwner(application)._lookupFactory('config:environment');
     if (!config || typeof config.firebase !== 'object') {
       throw new Error('Please set the `firebase` property in your environment config.');
     }

--- a/addon/torii-providers/firebase.js
+++ b/addon/torii-providers/firebase.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import Waitable from '../mixins/waitable';
 
+const { getOwner } = Ember;
 
 export default Ember.Object.extend(Waitable, {
   firebaseApp: Ember.inject.service(),
@@ -35,7 +36,7 @@ export default Ember.Object.extend(Waitable, {
 
       // oauth providers e.g. 'twitter'
       default:
-        const ProviderClass = this.container.lookupFactory(`firebase-auth-provider:${providerId}`);
+        const ProviderClass = getOwner(this).lookup(`firebase-auth-provider:${providerId}`);
         if (!ProviderClass) {
           return this.waitFor_(reject(new Error('Unknown provider')));
         }

--- a/tests/unit/services/firebase-app-test.js
+++ b/tests/unit/services/firebase-app-test.js
@@ -5,6 +5,9 @@ import {
 } from 'ember-mocha';
 import firebase from 'firebase';
 import sinon from 'sinon';
+import Ember from 'ember';
+
+const { setOwner } = Ember;
 
 describeModule(
   'emberfire@service:firebase-app',
@@ -19,10 +22,8 @@ describeModule(
     };
 
     const emberAppMock = {
-      container: {
-        lookupFactory() {
-          return configMock;
-        }
+      _lookupFactory() {
+        return configMock;
       }
     };
 
@@ -58,19 +59,22 @@ describeModule(
     });
 
     it('is the firebase app', function() {
-      const service = this.subject(emberAppMock);
+      setOwner(this, emberAppMock); // set owner context to mock app
+      const service = this.subject(this);
       expect(service).to.be.equal(firebaseAppMock);
     });
 
     it('initializes the app with the environment config', function() {
-      this.subject(emberAppMock);
+      setOwner(this, emberAppMock); // set owner context to mock app
+      this.subject(this);
       expect(initializeAppStub.calledWith(configMock.firebase)).to.be.true;
     });
 
     it('uses existing app if already present', function() {
       appStub.returns(firebaseAppMock);
 
-      this.subject(emberAppMock);
+      setOwner(this, emberAppMock); // set owner context to mock app
+      this.subject(this);
       expect(initializeAppStub.notCalled).to.be.true;
     });
   }

--- a/tests/unit/services/firebase-test.js
+++ b/tests/unit/services/firebase-test.js
@@ -5,6 +5,9 @@ import {
 } from 'ember-mocha';
 import firebase from 'firebase';
 import sinon from 'sinon';
+import Ember from 'ember';
+
+const { setOwner } = Ember;
 
 describeModule(
   'emberfire@service:firebase',
@@ -19,10 +22,8 @@ describeModule(
     };
 
     const emberAppMock = {
-      container: {
-        lookupFactory() {
-          return configMock;
-        }
+      _lookupFactory() {
+        return configMock;
       }
     };
 
@@ -58,19 +59,22 @@ describeModule(
     });
 
     it('is the database reference', function() {
-      const service = this.subject(emberAppMock);
+      setOwner(this, emberAppMock); // set owner context to mock app
+      const service = this.subject(this);
       expect(service).to.be.equal(refMock);
     });
 
     it('initializes the app with the environment config', function() {
-      this.subject(emberAppMock);
+      setOwner(this, emberAppMock); // set owner context to mock app
+      this.subject(this);
       expect(initializeAppStub.calledWith(configMock.firebase)).to.be.true;
     });
 
     it('uses existing app if already present', function() {
       appStub.returns(firebaseAppMock);
 
-      this.subject(emberAppMock);
+      setOwner(this, emberAppMock); // set owner context to mock app
+      this.subject(this);
       expect(initializeAppStub.notCalled).to.be.true;
     });
   }


### PR DESCRIPTION
Updated deprecated `container.lookup` calls to make use of the favoured
`getOwner()` function. Users of Ember 2.3 and above will no longer see
deprecation warnings about this.