### PR TITLE
Fastboot support

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,9 @@ module.exports = {
     }
     this.app = app;
 
-    this.app.import(app.bowerDirectory + '/firebase/firebase.js');
+    if (!process.env.EMBER_CLI_FASTBOOT) {
+      this.app.import(app.bowerDirectory + '/firebase/firebase.js');
+    }
 
     app.import('vendor/firebase/shim.js', {
       type: 'vendor',

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
     "ember-addon"
   ],
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "fastBootDependencies": [
+      "firebase"
+    ]
   },
   "browserify": {
     "transform": [
@@ -45,7 +48,8 @@
   "dependencies": {
     "chalk": "1.1.3",
     "ember-cli-babel": "5.1.6",
-    "ember-lodash": "0.0.7"
+    "ember-lodash": "0.0.7",
+    "firebase": "^3.4.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",

--- a/vendor/firebase/shim.js
+++ b/vendor/firebase/shim.js
@@ -1,9 +1,16 @@
-/* globals Firebase */
+/* globals firebase */
+var fb;
+
+if (window.FastBoot) {
+  fb = FastBoot.require('firebase');
+} else {
+  fb = firebase;
+}
 
 define('firebase', [], function() {
   "use strict";
 
   return {
-    'default': firebase
+    'default': fb
   };
 });


### PR DESCRIPTION
Basic fastboot support.

Allows reading data via the Firebase node library, there is no auth/session story yet.

All that is needed is:

```
ember fastboot --serve-assets
```


#410, #419