### PR TITLE
Documentation shows incorrect import for 'emberfire/torii-providers/firebase'

### DIFF
--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -21,7 +21,7 @@ This will inject a `session` property into our routes and controllers.
 In order to use Torii, we need to create a `app/torii-adapters/application.js` adapter file with the following code:
 
 ```js
-import ToriiFirebaseAdapter from 'emberfire/torii-adapters/firebase';
+import ToriiFirebaseAdapter from 'emberfire/torii-providers/firebase';
 export default ToriiFirebaseAdapter.extend({
 });
 ```


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual) before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

While following the Authentication part of the documentation, I kept running into a 'Could not find module' error and found out that 'emberfire/torii-providers/firebase' is the correct path to get the ToriiFirebaseAdapter.

