### PR TITLE
Change `fastBootDependencies` -> `fastbootDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "fastBootDependencies": [
+    "fastbootDependencies": [
       "firebase"
     ]
   },


### PR DESCRIPTION
This fixes the following deprecation:

```
DEPRECATION: ember-addon.fastBootDependencies has been replaced with ember-addon.fastbootDependencies [addon: emberfire]
```