### PR TITLE
Updating Ember versions tested against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ cache:
     - node_modules
 
 env:
-  - EMBER_TRY_SCENARIO=ember-data-2.5.x
-  - EMBER_TRY_SCENARIO=ember-data-2.6.x
-  - EMBER_TRY_SCENARIO=ember-data-2.7.x
-  - EMBER_TRY_SCENARIO=ember-data-2.8.x COVERAGE=true
+  - EMBER_TRY_SCENARIO=ember-data-2.8.x
+  - EMBER_TRY_SCENARIO=ember-data-2.9.x
+  - EMBER_TRY_SCENARIO=ember-data-2.10.x
+  - EMBER_TRY_SCENARIO=ember-data-2.11.x COVERAGE=true
   - EMBER_TRY_SCENARIO=ember-data-beta
   - EMBER_TRY_SCENARIO=ember-data-canary
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,34 +2,34 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-data-2.5.x',
-      npm: {
-        devDependencies: {
-          'ember-data': '~2.5.0'
-        }
-      }
-    },
-    {
-      name: 'ember-data-2.6.x',
-      npm: {
-        devDependencies: {
-          'ember-data': '~2.6.0'
-        }
-      }
-    },
-    {
-      name: 'ember-data-2.7.x',
-      npm: {
-        devDependencies: {
-          'ember-data': '~2.7.0'
-        }
-      }
-    },
-    {
       name: 'ember-data-2.8.x',
       npm: {
         devDependencies: {
           'ember-data': '~2.8.0'
+        }
+      }
+    },
+    {
+      name: 'ember-data-2.9.x',
+      npm: {
+        devDependencies: {
+          'ember-data': '~2.9.0'
+        }
+      }
+    },
+    {
+      name: 'ember-data-2.10.x',
+      npm: {
+        devDependencies: {
+          'ember-data': '~2.10.0'
+        }
+      }
+    },
+    {
+      name: 'ember-data-2.11.x',
+      npm: {
+        devDependencies: {
+          'ember-data': '~2.11.0'
         }
       }
     },


### PR DESCRIPTION
2.8.3 is the latest LTS build, 2.11.0 the latest stable. Test against those in Travis.