### PR TITLE
fix #480, use scheduleOnce instead of run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 npm-debug.log
 testem.log
 .firebaserc
+/.project

--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -145,11 +145,11 @@ export default DS.Adapter.extend(Waitable, {
 
       ref.once('value', (snapshot) => {
         this._decrementWaiters();
-        Ember.run(null, resolve, snapshot);
+        Ember.run.scheduleOnce('afterRender', this, resolve, snapshot);
 
       }, (err) => {
         this._decrementWaiters();
-        Ember.run(null, reject, err);
+        Ember.run.scheduleOnce('afterRender', this, reject, err);
       });
 
     }, log);


### PR DESCRIPTION

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual) before sending PRs. We cannot accept code without this.

-->


### Description
Use scheduleOnce instead of firing as soon as we receive a value change message. Had to set ember-data to 2.10 for test to pass. This avoid entering in a long loop that make ember think we are infinite looping.


