### PR TITLE
Fix #475 Embedded hasmany delete bug

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -804,14 +804,29 @@ export default DS.Adapter.extend(Waitable, {
    */
   _updateRecordCacheForType(typeClass, payload, store) {
     if (!payload) { return; }
-    var id = payload.id;
-    var cache = this._getRecordCache(typeClass, id);
+    const id = payload.id;
+    const cache = this._getRecordCache(typeClass, id);
     const serializer = store.serializerFor(typeClass.modelName);
     // Only cache relationships for now
+    // and do the same for embedded records
     typeClass.eachRelationship((key, relationship) => {
       if (relationship.kind === 'hasMany') {
-        var ids = payload[serializer.keyForRelationship(key)];
-        cache[key] = !Ember.isNone(ids) ? Ember.A(Object.keys(ids)) : Ember.A();
+        const relationshipPayload = payload[serializer.keyForRelationship(key)];
+        if (!relationshipPayload) {
+          cache[key] = Ember.A();
+        } else {
+          const isEmbedded = this.isRelationshipEmbedded(store, typeClass.modelName, relationship);
+          if (isEmbedded) {
+            const relationshipTypeClass = store.modelFor(relationship.type);
+            forEach(relationshipPayload, (obj, id) => {
+              obj.id = id;
+              this._updateRecordCacheForType(relationshipTypeClass, obj, store);
+            });
+          } else {
+            const ids = Object.keys(relationshipPayload);
+            cache[key] = Ember.A(ids);
+          }
+        }
       }
     });
   },


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual) before sending PRs. We cannot accept code without this.

-->


### Description

Fixing a problem with removing child objects from embedded records when using hasMany relationship (#475). The problem was related with not keeping embedded hasMany records in cache. Then when saving hasMany relationship after removing an object from object's collection, removed object is not being marked for deletion because it was not cached.