### PR TITLE
Fix deprecations for Ember/Ember-Data 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ env:
   - EMBER_TRY_SCENARIO=ember-data-2.8.x
   - EMBER_TRY_SCENARIO=ember-data-2.9.x
   - EMBER_TRY_SCENARIO=ember-data-2.10.x
-  - EMBER_TRY_SCENARIO=ember-data-2.11.x COVERAGE=true
+  - EMBER_TRY_SCENARIO=ember-data-2.11.x
+  - EMBER_TRY_SCENARIO=ember-data-2.12.x COVERAGE=true
   - EMBER_TRY_SCENARIO=ember-data-beta
   - EMBER_TRY_SCENARIO=ember-data-canary
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
   - "4"
 
 addons:
-  firefox: latest
+  firefox: "51" # lock firefox version until testem/firefox fix https://github.com/testem/testem/issues/1084
   code_climate:
     repo_token:
       secure: gQhPZkdkqJi1XbgJpe23Ji90VQCuXLV1yOp0L1JH+Hx4L19L+mn3gEbB99bFa/Lbh4ASwpuapHy6w2VUn6mzHknbD8r0me7g5bebGFcDyPf+EOVHEzAScnFHrKIqjK/sCbvcI7xWvDpzg9kT9UTBAdVfiJYEYiPEnKskPy8FIE0=

--- a/addon/serializers/firebase.js
+++ b/addon/serializers/firebase.js
@@ -291,6 +291,14 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
   /**
    * @override
    */
+  shouldSerializeHasMany(snapshot, key, relationship) {
+    return this._canSerialize(key);
+  },
+
+  /**
+   * @override
+   * @deprecated
+   */
   _shouldSerializeHasMany(snapshot, key, relationship) {
     return this._canSerialize(key);
   }

--- a/addon/services/firebase-app.js
+++ b/addon/services/firebase-app.js
@@ -5,7 +5,7 @@ const { getOwner } = Ember;
 
 export default {
   create(application) {
-    const config = getOwner(application)._lookupFactory('config:environment');
+    const config = getOwner(application).factoryFor('config:environment');
     if (!config || typeof config.firebase !== 'object') {
       throw new Error('Please set the `firebase` property in your environment config.');
     }

--- a/addon/services/firebase-app.js
+++ b/addon/services/firebase-app.js
@@ -5,7 +5,7 @@ const { getOwner } = Ember;
 
 export default {
   create(application) {
-    const config = getOwner(application).factoryFor('config:environment');
+    const config = getOwner(application).resolveRegistration('config:environment');
     if (!config || typeof config.firebase !== 'object') {
       throw new Error('Please set the `firebase` property in your environment config.');
     }

--- a/addon/services/firebase.js
+++ b/addon/services/firebase.js
@@ -5,7 +5,7 @@ const { getOwner } = Ember;
 
 export default {
   create(application) {
-    const config = getOwner(application)._lookupFactory('config:environment');
+    const config = getOwner(application).factoryFor('config:environment');
     if (!config || typeof config.firebase !== 'object') {
       throw new Error('Please set the `firebase` property in your environment config.');
     }

--- a/addon/services/firebase.js
+++ b/addon/services/firebase.js
@@ -5,7 +5,7 @@ const { getOwner } = Ember;
 
 export default {
   create(application) {
-    const config = getOwner(application).factoryFor('config:environment');
+    const config = getOwner(application).resolveRegistration('config:environment');
     if (!config || typeof config.firebase !== 'object') {
       throw new Error('Please set the `firebase` property in your environment config.');
     }

--- a/config/coverage.js
+++ b/config/coverage.js
@@ -1,3 +1,4 @@
+/* jshint node: true */
 module.exports = {
   excludes: ['*/mirage/**/*', 'tests/dummy/**/*'],
   useBabelInstrumenter: true

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -34,24 +34,26 @@ module.exports = {
       }
     },
     {
+      name: 'ember-data-2.12.x',
+      npm: {
+        devDependencies: {
+          'ember-data': '~2.12.0'
+        }
+      }
+    },
+    {
       name: 'ember-data-beta',
-      bower: {
-        dependencies: {
-          'ember-data': 'components/ember-data#beta'
-        },
-        resolutions: {
-          'ember-data': 'components/ember-data#beta'
+      npm: {
+        devDependencies: {
+          'ember-data': 'emberjs/data#beta'
         }
       }
     },
     {
       name: 'ember-data-canary',
-      bower: {
-        dependencies: {
-          'ember-data': 'components/ember-data#canary'
-        },
-        resolutions: {
-          'ember-data': 'components/ember-data#canary'
+      npm: {
+        devDependencies: {
+          'ember-data': 'emberjs/data#master'
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "chalk": "1.1.3",
     "ember-cli-babel": "5.1.6",
     "ember-lodash": "0.0.7",
+    "ember-factory-for-polyfill": "^1.1.1",
     "firebase": "^3.4.1"
   },
   "devDependencies": {
@@ -74,7 +75,6 @@
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.2.2",
     "loader.js": "^4.0.1",
-
     "babelify": "6.4.0",
     "browserify-shim": "3.8.12",
     "browserify": "10.2.6",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "chalk": "1.1.3",
     "ember-cli-babel": "5.1.6",
     "ember-lodash": "0.0.7",
-    "ember-factory-for-polyfill": "^1.1.1",
     "firebase": "^3.4.1"
   },
   "devDependencies": {

--- a/tests/integration/queries-test.js
+++ b/tests/integration/queries-test.js
@@ -27,7 +27,7 @@ describe('Integration: FirebaseAdapter - Queries', function() {
 
     var query = { limitToLast: 3 };
 
-    queryArray = store.recordArrayManager.createAdapterPopulatedRecordArray(store.modelFor('post'), query);
+    queryArray = store.recordArrayManager.createAdapterPopulatedRecordArray('post', query);
 
     run(function () {
       adapter.query(store, store.modelFor('post'), query, queryArray)
@@ -92,7 +92,7 @@ describe('Integration: FirebaseAdapter - Queries', function() {
         limitToLast: 1,
       };
 
-      queryArray = store.recordArrayManager.createAdapterPopulatedRecordArray(store.modelFor('post'), query);
+      queryArray = store.recordArrayManager.createAdapterPopulatedRecordArray('post', query);
 
       run(() => {
         adapter.query(store, store.modelFor('post'), query, queryArray)

--- a/tests/unit/services/firebase-app-test.js
+++ b/tests/unit/services/firebase-app-test.js
@@ -18,7 +18,7 @@ describe('FirebaseAppService', function() {
   };
 
   const emberAppMock = {
-    _lookupFactory() {
+    factoryFor() {
       return configMock;
     }
   };

--- a/tests/unit/services/firebase-app-test.js
+++ b/tests/unit/services/firebase-app-test.js
@@ -18,7 +18,7 @@ describe('FirebaseAppService', function() {
   };
 
   const emberAppMock = {
-    factoryFor() {
+    resolveRegistration() {
       return configMock;
     }
   };

--- a/tests/unit/services/firebase-test.js
+++ b/tests/unit/services/firebase-test.js
@@ -18,7 +18,7 @@ describe('FirebaseService', function() {
   };
 
   const emberAppMock = {
-    _lookupFactory() {
+    factoryFor() {
       return configMock;
     }
   };

--- a/tests/unit/services/firebase-test.js
+++ b/tests/unit/services/firebase-test.js
@@ -18,7 +18,7 @@ describe('FirebaseService', function() {
   };
 
   const emberAppMock = {
-    factoryFor() {
+    resolveRegistration() {
       return configMock;
     }
   };


### PR DESCRIPTION
### Description

Since ember and ember-data 2.12 become stable there are deprecations needed to be fixed.
1. `_lookupFactoryFor` – [link](http://emberjs.com/deprecations/v2.x/#toc_migrating-from-_lookupfactory-to-factoryfor). ~~I have added polyfill as suggested at Ember blog.~~ Replaced with [#resolveRegistration()](https://github.com/null-null-null/ember-get-config#ember-get-config) method.
2. `_shouldSerializeHasMany` – [link](http://emberjs.com/deprecations/ember-data/v2.x/#toc_jsonserializer-shouldserializehasmany). It is now public API, but I kept both. Please let me know if you have any notices.

Some other changes:
1. I have copied ember-try  scenarios from this [PR](https://github.com/firebase/emberfire/pull/491) to test against new ember versions so original PR may be obsolete.
2. ember-try scenarios contained wrong dependencies for ember-canary and ember-beta. I fixed them to use npm instead of bower.
3. Tests have helper to get user by username or create new. It used removed method `typeMapFor`, now it uses `_internalModelsFor`. 
4. Coverage config had problems with linting because of env, I fixed it with jshint comment.

Local tests passed all scenarios and linting. Let see if it will works the same on Travis :)

EDIT.

There was problem with [testem/firefox](https://github.com/testem/testem/issues/1084) and I locked Firefox to 51 until fix.