### PR TITLE
Use resolveRegistration to lookup firebase auth providers.

### DIFF
--- a/addon/torii-providers/firebase.js
+++ b/addon/torii-providers/firebase.js
@@ -36,7 +36,7 @@ export default Ember.Object.extend(Waitable, {
 
       // oauth providers e.g. 'twitter'
       default:
-        const ProviderClass = getOwner(this).lookup(`firebase-auth-provider:${providerId}`);
+        const ProviderClass = getOwner(this).resolveRegistration(`firebase-auth-provider:${providerId}`);
         if (!ProviderClass) {
           return this.waitFor_(reject(new Error('Unknown provider')));
         }


### PR DESCRIPTION
### Description

When using `emberfire` with `Ember 2.12` authentication is not working.

Before code used to find provider class utilized method `lookup`. It tries to find `firebase-auth-provider:<provider>` factory but nothing was found.

```js
const ProviderClass = getOwner(this).lookup(`firebase-auth-provider:${providerId}`);
```

Instead we need to use `resolveRegistration` to find auth provider.

```js
const ProviderClass = getOwner(this).resolveRegistration(`firebase-auth-provider:${providerId}`);
```

This PR should fix Issue #493.
