### PR TITLE
Removed ArrayController

### DIFF
--- a/docs/guide/saving-and-retrieving-data.md
+++ b/docs/guide/saving-and-retrieving-data.md
@@ -46,7 +46,7 @@ $ ember generate controller posts
 
 ```js
 // app/controllers/posts.js
-export default Ember.ArrayController.extend({
+export default Ember.Controller.extend({
   sortProperties: ['timestamp'],
   sortAscending: false, // sorts post by timestamp
   actions: {
@@ -62,7 +62,7 @@ export default Ember.ArrayController.extend({
 });
 ```
 
-We used an **ArrayController** to sort our posts by timestamp. In our `publishPost` action, we create a new post in the data store with the title and body entered in our Handlebars template. Simply calling `newPost.save()` will save our post to the data store and automatically create a record in the database.
+In our `publishPost` action, we create a new post in the data store with the title and body entered in our Handlebars template. Simply calling `newPost.save()` will save our post to the data store and automatically create a record in the database.
 
 > **Note:** By default Firebase requires users be authenticated before they can read and write to the database. If you have not authenticated your users, you will receive errors . If you want to allow reading/writing to the database from unauthenticated users, check out the [security rules](security-rules.md) section.
 


### PR DESCRIPTION
I tried following through this tutorial myself and found the code to not work. From what I've found online, ArrayController has been deprecated. I was able to finish the tutorial by simply swapping 'ArrayController' to 'Controller'

Source: http://stackoverflow.com/questions/32047853/is-controller-deprecated-in-ember-2-0

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual) before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
