### PR TITLE
Improve query application

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -316,8 +316,27 @@ export default DS.Adapter.extend(Waitable, {
       ref = ref.orderByChild(query.orderBy);
     }
 
-    ['startAt', 'endAt', 'equalTo', 'limitToFirst', 'limitToLast'].forEach(function (key) {
-      if (query[key] || query[key] === '' || query[key] === false) {
+    ref = this._applyRangesToRef(ref, query);
+    ref = this._applyLimitsToRef(ref, query);
+
+    return ref;
+  },
+
+  _applyRangesToRef(ref, query) {
+    const methods = ['equalTo', 'startAt', 'endAt'];
+    methods.forEach(key => {
+      if (query[key] !== undefined) {
+        ref = ref[key](query[key]);
+      }
+    });
+
+    return ref;
+  },
+
+  _applyLimitsToRef(ref, query) {
+    const methods = ['limitToFirst', 'limitToLast'];
+    methods.forEach(key => {
+      if (Number.isInteger(query[key])) {
         ref = ref[key](query[key]);
       }
     });

--- a/tests/unit/adapters/firebase-test.js
+++ b/tests/unit/adapters/firebase-test.js
@@ -90,45 +90,86 @@ describe('FirebaseAdapter', function() {
         queryMethodStub.restore();
       });
 
-      it(`calls ${method} and passes through value when specified`, function () {
-        var query = {};
+      if (method === 'limitToFirst' || method === 'limitToLast') {
+        it(`calls ${method} and passes through value when an integer`, function () {
+          var query = {};
 
-        query[method] = 'value';
+          query[method] = 10;
 
-        adapter.applyQueryToRef(ref, query);
-        expect(queryMethodStub.calledOnce).to.be.ok;
-        expect(queryMethodStub.calledWith('value')).to.be.ok;
-      });
+          adapter.applyQueryToRef(ref, query);
+          expect(queryMethodStub.calledOnce).to.be.ok;
+          expect(queryMethodStub.calledWith(10)).to.be.ok;
+        });
 
-      it(`calls ${method} and passes through value when empty string`, function () {
-        var query = {};
+        it(`does not call ${method} when the value is null`, function () {
+          var query = {};
 
-        query[method] = '';
+          query[method] = null;
 
-        adapter.applyQueryToRef(ref, query);
-        expect(queryMethodStub.calledOnce).to.be.ok;
-        expect(queryMethodStub.calledWith('')).to.be.ok;
-      });
+          adapter.applyQueryToRef(ref, query);
+          expect(queryMethodStub.called === false, `${method} should not be called`).to.be.ok;
+        });
 
-      it(`calls ${method} and passes through value when 'false'`, function () {
-        var query = {};
+        it(`does not call ${method} when value is a string`, function () {
+          var query = {};
 
-        query[method] = false;
+          query[method] = 'value';
 
-        adapter.applyQueryToRef(ref, query);
-        expect(queryMethodStub.calledOnce).to.be.ok;
-        expect(queryMethodStub.calledWith(false)).to.be.ok;
-      });
+          adapter.applyQueryToRef(ref, query);
+          expect(queryMethodStub.called === false, `${method} should not be called`).to.be.ok;
+        });
 
-      it(`does not call ${method} when the value is null`, function () {
-        var query = {};
+        it(`does not call ${method} when value is 'false'`, function () {
+          var query = {};
 
-        query[method] = null;
+          query[method] = false;
 
-        adapter.applyQueryToRef(ref, query);
-        expect(queryMethodStub.called === false, `${method} should not be called`).to.be.ok;
-      });
+          adapter.applyQueryToRef(ref, query);
+          expect(queryMethodStub.called === false, `${method} should not be called`).to.be.ok;
+        });
 
+      } else {
+        it(`calls ${method} when the value is null`, function () {
+          var query = {};
+
+          query[method] = null;
+
+          adapter.applyQueryToRef(ref, query);
+          expect(queryMethodStub.calledOnce).to.be.ok;
+          expect(queryMethodStub.calledWith(null)).to.be.ok;
+        });
+
+        it(`calls ${method} and passes through value when specified`, function () {
+          var query = {};
+
+          query[method] = 'value';
+
+          adapter.applyQueryToRef(ref, query);
+          expect(queryMethodStub.calledOnce).to.be.ok;
+          expect(queryMethodStub.calledWith('value')).to.be.ok;
+        });
+
+        it(`calls ${method} and passes through value when empty string`, function () {
+          var query = {};
+
+          query[method] = '';
+
+          adapter.applyQueryToRef(ref, query);
+          expect(queryMethodStub.calledOnce).to.be.ok;
+          expect(queryMethodStub.calledWith('')).to.be.ok;
+        });
+
+        it(`calls ${method} and passes through value when 'false'`, function () {
+          var query = {};
+
+          query[method] = false;
+
+          adapter.applyQueryToRef(ref, query);
+          expect(queryMethodStub.calledOnce).to.be.ok;
+          expect(queryMethodStub.calledWith(false)).to.be.ok;
+        });
+
+      }
     }); // forEach
 
   }); // #applyQueryToRef


### PR DESCRIPTION
Fixes #506 and also allows `startAt`, `endAt` and `equalTo` to accept `null` since it is a valid value for these methods when ordering by child. For `limitToFirst` and `limitToLast` only integer values will be added to the query.

