### PR TITLE
More robust addon/engine support

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,12 +9,14 @@ module.exports = {
   name: 'emberfire',
 
   included: function included(app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
+    var app;
 
     // make sure app is correctly assigned when being used as a nested addon
-    if (app.app) {
-      app = app.app;
-    }
+    var current = this;
+    do{
+      app = current.app || app;
+    } while (current.parent.parent && (current = current.parent));
     this.app = app;
 
     this.app.import('vendor/firebase.amd.js');


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual) before sending PRs. We cannot accept code without this.

-->


### Description
This PR properly invokes super (it should be bound) and also uses a more robust method to find `app` (to deal with addons-of-addons situations).

The unbounded super call causes an issue in Ember CLI 2.12.

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample
```
 this._super.included.apply(this, arguments);
```

```
do{
  app = current.app || app;
} while (current.parent.parent && (current = current.parent));
this.app = app;
this.app.import('vendor/firebase.amd.js');
```
<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
