### PR TITLE
fix: ember global import in 3.0

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import DS from 'ember-data';
 import Waitable from '../mixins/waitable';
 import toPromise from '../utils/to-promise';

--- a/addon/initializers/emberfire.js
+++ b/addon/initializers/emberfire.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import DS from 'ember-data';
 import firebase from 'firebase';
 import FirebaseAdapter from '../adapters/firebase';

--- a/addon/mixins/waitable.js
+++ b/addon/mixins/waitable.js
@@ -1,5 +1,3 @@
-import Ember from 'ember';
-
 export default Ember.Mixin.create({
 
   init() {

--- a/addon/serializers/firebase.js
+++ b/addon/serializers/firebase.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import DS from 'ember-data';
 import firebase from 'firebase';
 

--- a/addon/services/firebase-app.js
+++ b/addon/services/firebase-app.js
@@ -1,5 +1,4 @@
 import firebase from 'firebase';
-import Ember from 'ember';
 
 const { getOwner } = Ember;
 

--- a/addon/services/firebase.js
+++ b/addon/services/firebase.js
@@ -1,5 +1,4 @@
 import firebase from 'firebase';
-import Ember from 'ember';
 
 const { getOwner } = Ember;
 

--- a/addon/torii-adapters/firebase.js
+++ b/addon/torii-adapters/firebase.js
@@ -1,5 +1,3 @@
-import Ember from 'ember';
-
 export default Ember.Object.extend({
   firebaseApp: Ember.inject.service(),
 

--- a/addon/torii-providers/firebase.js
+++ b/addon/torii-providers/firebase.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import Waitable from '../mixins/waitable';
 
 const { getOwner } = Ember;

--- a/addon/utils/to-promise.js
+++ b/addon/utils/to-promise.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 
 export default function(fn, context, _args, errorMsg) {
   var args = _args || [];


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual) before sending PRs. We cannot accept code without this.

-->


### Description

workaround for the error thrown in Ember 3.x; importing 'ember' directly is no longer supported. The proper fix would be to refactor the code to remove reliance on the global Ember var and instead import the correct submodules.

### Code sample

No code changes should be required from the end-developers.