### PR TITLE
Fix ember data deprecation

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -818,6 +818,7 @@ export default DS.Adapter.extend(Waitable, {
    * _updateHasManyCacheForType
    */
   _updateRecordCacheForType(typeClass, payload, store) {
+    if (store.isDestroying || store.isDestroyed) { return; }
     if (!payload) { return; }
     const id = payload.id;
     const cache = this._getRecordCache(typeClass, id);


### PR DESCRIPTION
- emberfire 2.0.10
- ember-data 3.4.0
- ember-cli-fastboot 2.0.0

I'm seeing the following deprecation with ember fastboot: `ember-data:method-calls-on-destroyed-store`. It does not happen without fastboot.

I tested the change on an app of mine where it is working. But I don't know which implications returning early here has.

Also see https://github.com/emberjs/data/pull/5640/files