### PR TITLE
fix native js call to super

### DIFF
--- a/addon/services/firebase-app.ts
+++ b/addon/services/firebase-app.ts
@@ -38,6 +38,7 @@ export default class FirebaseAppService extends Service.extend({
     storage     = (url?: string)    => resolve(import(<any>'firebase/storage')    ).then(() => getApp(this).storage(url));
 
     init(...args: any[]) {
+        // @ts-ignore because ember do pass arguments here
         super.init(...args);
         const app = getApp(this);
         set(this, 'options', app.options);

--- a/addon/services/firebase-app.ts
+++ b/addon/services/firebase-app.ts
@@ -38,7 +38,7 @@ export default class FirebaseAppService extends Service.extend({
     storage     = (url?: string)    => resolve(import(<any>'firebase/storage')    ).then(() => getApp(this).storage(url));
 
     init() {
-        this._super(...arguments);
+        super.init(...arguments);
         const app = getApp(this);
         set(this, 'options', app.options);
     }

--- a/addon/services/firebase-app.ts
+++ b/addon/services/firebase-app.ts
@@ -37,8 +37,8 @@ export default class FirebaseAppService extends Service.extend({
     performance = ()                => resolve(import(<any>'firebase/performance')).then(() => getApp(this).performance());
     storage     = (url?: string)    => resolve(import(<any>'firebase/storage')    ).then(() => getApp(this).storage(url));
 
-    init() {
-        super.init(...arguments);
+    init(...args: any[]) {
+        super.init(...args);
         const app = getApp(this);
         set(this, 'options', app.options);
     }


### PR DESCRIPTION
### Description
Fixing an error on firebaseApp service loading.
```
Assertion Failed: You must call `this._super(...arguments);` when overriding `init` on a framework object. 
Please update <app@service:firebase-app::ember180> to call `this._super(...arguments);` from `init`.
```

Note that I had an issue with typescript compilation. Initially I followed Ember conventions by using `super.init(...arguments);` like they do here: https://github.com/emberjs/ember.js/blob/master/packages/@ember/-internals/routing/lib/services/router.ts#L64-L65

Then I have tried to workaround the typescript error but IMHO I think the way Ember did is the correct.