### PR TITLE
WIP realtime relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ export default DS.Model.extend({
 // app/routes/articles.js
 import Route from '@ember/routing/route';
 import RealtimeRouteMixin from 'emberfire/mixins/realtime-route';
+import PerformanceRouteMixin from 'emberfire/mixins/performance-route';
 
-export default Route.extend(RealtimeRouteMixin, {
+export default Route.extend(RealtimeRouteMixin, PerformanceRouteMixin, {
     model() {
         return this.store.query('article', { orderBy: 'publishedAt' });
     }

--- a/addon/mixins/performance-route.ts
+++ b/addon/mixins/performance-route.ts
@@ -1,0 +1,42 @@
+import { inject as service } from '@ember/service';
+import Mixin from '@ember/object/mixin';
+import { performance } from 'firebase';
+import { Promise, reject } from 'rsvp';
+
+export default Mixin.create({
+    firebaseApp: service('firebase-app'),
+    store: service('store') as any,
+    router: service('router'),
+    trace: reject() as Promise<performance.Trace>,
+    init() {
+        this._super(...arguments);
+        this.get('firebaseApp').performance();
+        // TODO see if I can fix this
+        if (this.toString().indexOf("@route:application::") > 0) { throw "PerformanceRouteMixin does not work correctly in the application route" }
+    },
+    beforeModel() {
+        // TODO promise proxy
+        this.set('trace', this.get('firebaseApp').performance().then(perf => {
+            const trace = perf.trace(`${this.toString()}:didTransition`);
+            trace.start();
+            return trace;
+        }));
+    },
+    afterModel() {
+        const tracePromise = this.get('trace')!;
+        const router = this.get('router');
+        tracePromise.then((trace:performance.Trace|undefined) => {
+            // TODO figure out how to disconnect the routeDidChange listener
+            router.on('routeDidChange', () => {
+                if (trace) {
+                    const screen_name = router.currentRouteName;
+                    trace.putAttribute('url', router.currentURL);
+                    (trace as any).name = `${screen_name}:didTransition`;
+                    trace.stop();
+                    this.set('trace', reject());
+                    trace = undefined;
+                }
+            });
+        })
+    }
+});

--- a/addon/services/firebase-app.ts
+++ b/addon/services/firebase-app.ts
@@ -3,9 +3,7 @@ import { get, set } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Ember from 'ember';
 import FirebaseService from './firebase';
-
-import RSVP from 'rsvp';
-const { resolve } = RSVP;
+import { resolve } from 'rsvp';
 
 const getApp = (service: FirebaseAppService) => {
     const firebase = get(service, 'firebase');

--- a/addon/services/realtime-listener.ts
+++ b/addon/services/realtime-listener.ts
@@ -8,6 +8,7 @@ import { firestore, database } from 'firebase/app';
 // TODO don't hardcode these, but having trouble otherwise
 import { rootCollection as firestoreRootCollection } from '../adapters/firestore';
 import { rootCollection as realtimeDatabaseRootCollection } from '../adapters/realtime-database';
+import { resolve } from 'rsvp';
 
 const getService = (object:Object) => getOwner(object).lookup('service:realtime-listener') as RealtimeListenerService;
 const isFastboot = (object:Object) => {
@@ -56,74 +57,59 @@ function isFirestoreDocumentRefernce(arg: any): arg is firestore.DocumentReferen
     return arg.onSnapshot !== undefined;
 }
 
-type SubscribeArgs = {
-    model: any;
-    store: DS.Store;
-    modelName: never;
-    modelClass: any;
-    uniqueIdentifier: any;
-    serializer: any;
-    adapter: never;
-    parentModel: any;
-    relationshipName: string|undefined;
-}
-
-type FirestoreQueryArgs = {
-    query: firestore.Query | firestore.CollectionReference
-} & SubscribeArgs
-
-type RealtimeDatabaseQueryArgs = {
-    ref: database.Reference
-} & SubscribeArgs
-
 export default class RealtimeListenerService extends Service.extend({
 
     routeSubscriptions: {} as {[key:string]: {[key:string]: () => void}}
 
 }) {
 
-    subscribe(route: Object, model: any, parentModel?: any, relationshipName?:string) {
+    subscribe(route: Object, model: any, parentModel?: any, relationship?:any) {
+        if (!model) { return }
         const store = model.store as DS.Store;
-        const modelName = (model.modelName || model.get('_internalModel.modelName')) as never
+        const modelName = (model.get('type.modelName') || model.get('_internalModel.modelName') || model.modelName) as never
         const modelClass = store.modelFor(modelName) as any;
-        const query = model.get('meta.query') as firestore.Query|database.Reference|undefined;
-        const ref = model.get('_internalModel._recordData._data._ref') as firestore.DocumentReference|database.Reference|undefined;
+        const ref = (model.get('meta._ref') || model.get('_recordData._data._ref') || model.get('_internalModel._recordData._data._ref')) as firestore.DocumentReference|database.Reference|undefined;
         const uniqueIdentifier = model.toString();
         const serializer = store.serializerFor(modelName) as any; // TODO type
         const adapter = store.adapterFor(modelName);
-        const args = { model, store, modelName, modelClass, uniqueIdentifier, serializer, adapter, parentModel, relationshipName };
         const observeRelationships = (internalModel: any) => {
             // HACK HACK HACK
-            internalModel._originalUpdatePromiseProxyFor = internalModel._updatePromiseProxyFor;
-            internalModel._updatePromiseProxyFor = (...args: any[]) => {
-                const proxy = internalModel._originalUpdatePromiseProxyFor(...args);
-                proxy.then((result:any) => {
-                    if (result) {
-                        // TODO what happens when the relationship changes?
-                        this.subscribe(route, result, model, args[1]);
-                    }
-                });
-                return proxy;
+            const movedKey = '__original___updatePromiseProxyFor';
+            const proxyPromiseListenersKey = `_updatePromiseProxyListeners`;
+            const requestedRelationshipsKey = '_requestedRelationships';
+            if (!internalModel[requestedRelationshipsKey]) { internalModel[requestedRelationshipsKey] = [] }
+            const movedMethod = internalModel[movedKey];
+            if (!movedMethod) {
+                internalModel[movedKey] = internalModel._updatePromiseProxyFor;
+                internalModel[proxyPromiseListenersKey] = [];
+                internalModel._updatePromiseProxyFor = ((kind: string, key: string, args: Object) => {
+                    const proxy = internalModel[movedKey](kind, key, args);
+                    proxy.then((result:any) => {
+                        if (internalModel[requestedRelationshipsKey].indexOf(key) < 0) {
+                            internalModel[requestedRelationshipsKey] = [...internalModel[requestedRelationshipsKey], key];
+                            internalModel[proxyPromiseListenersKey].forEach((f:any) => f(kind, key, args, result));
+                        }
+                    });
+                    return proxy;
+                })
             }
+            internalModel[proxyPromiseListenersKey] = [
+                ...internalModel[proxyPromiseListenersKey],
+                ((kind: string, key: string, args: Object, result: any) => {
+                    const triggerdRelationship = modelClass.relationshipsObject[key];
+                    this.subscribe(route, result, model, triggerdRelationship);
+                })
+            ];
         }
+        let content = model.content || parentModel && get(parentModel, `${relationship.key}.content`);
         if (model._internalModel) {
-            observeRelationships(model);
-        } else {
-            model.content.forEach((internalModel:any) => {
+            observeRelationships(model._internalModel);
+        } else if (content) { // TODO find backing content for hasMany
+            content.forEach((internalModel:any) => {
                 observeRelationships(internalModel);
             });
         }
-        if (query) {
-            if (isFirestoreQuery(query)) {
-                // Firestore query
-                const unsubscribe = runFirestoreCollectionListener({query, ...args});
-                setRouteSubscription(this, route, uniqueIdentifier, unsubscribe);
-            } else {
-                // RTDB query
-                const unsubscribe = runRealtimeDatabaseListListener({ref: query, ...args});
-                setRouteSubscription(this, route, uniqueIdentifier, unsubscribe);
-            }
-        } else if (ref) {
+        if (ref) {
             if (isFirestoreDocumentRefernce(ref)) {
                 // Firestore find
                 const unsubscribe = ref.onSnapshot(doc => {
@@ -152,17 +138,109 @@ export default class RealtimeListenerService extends Service.extend({
                 setRouteSubscription(this, route, uniqueIdentifier, unsubscribe);
             }
         } else {
-            // findAll ditches the metadata :(
             if (serializer.constructor.name == 'FirestoreSerializer') {
                 // Firestore findAll
-                firestoreRootCollection(adapter, modelName).then(query => {
-                    const unsubscribe = runFirestoreCollectionListener({query, ...args});
+                const query = model.get('meta.query') as firestore.Query|undefined;
+                const queryOrRoot = query && resolve(query) || firestoreRootCollection(adapter, modelName);
+                queryOrRoot.then(query => {
+                    const unsubscribe = query.onSnapshot(snapshot => {
+                        snapshot.docChanges().forEach(change => run(() => {
+                            const normalizedData = serializer.normalizeSingleResponse(store, modelClass, change.doc);
+                            switch(change.type) {
+                                case 'added': {
+                                    const current = content.objectAt(change.newIndex);
+                                    if (current == null || current.id !== change.doc.id ) {
+                                        const doc = store.push(normalizedData) as any;
+                                        content.insertAt(change.newIndex, doc._internalModel);
+                                    }
+                                    break;
+                                }
+                                case 'modified': {
+                                    const current = content.objectAt(change.oldIndex);
+                                    if (current == null || current.id == change.doc.id) {
+                                        if (change.newIndex !== change.oldIndex) {
+                                            content.removeAt(change.oldIndex);
+                                            content.insertAt(change.newIndex, current)
+                                        }
+                                    }
+                                    store.push(normalizedData);
+                                    break;
+                                }
+                                case 'removed': {
+                                    const current = content.objectAt(change.oldIndex);
+                                    if (current && current.id == change.doc.id) {
+                                        content.removeAt(change.oldIndex);
+                                    }
+                                    break;
+                                }
+                            }
+                        }))
+                    });
                     setRouteSubscription(this, route, uniqueIdentifier, unsubscribe);
                 });
             } else if (serializer.constructor.name == 'RealtimeDatabaseSerializer') {
                 // RTDB findAll
-                realtimeDatabaseRootCollection(adapter, modelName).then(ref => {
-                    const unsubscribe = runRealtimeDatabaseListListener({ref, ...args});
+                const ref = (model.get('meta.query') || model.get('recordData._data._ref')) as database.Reference|undefined;
+                const refOrRoot = ref ? resolve(ref) : realtimeDatabaseRootCollection(adapter, modelName);
+                refOrRoot.then(ref => {
+                    const onChildAdded = ref.on('child_added', (snapshot, priorKey) => {
+                        run(() => {
+                            if (snapshot) {
+                                const normalizedData = serializer.normalizeSingleResponse(store, modelClass, snapshot);
+                                const doc = store.push(normalizedData) as any;
+                                const existing = content.find((record:any) => record.id === doc.id);
+                                if (existing) { content.removeObject(existing); }
+                                let insertIndex = 0;
+                                if (priorKey) {
+                                    const record = content.find((record:any) => record.id === priorKey);
+                                    insertIndex = content.indexOf(record) + 1;
+                                }
+                                const current = content.objectAt(insertIndex);
+                                if (current == null || current.id !== doc.id ) {
+                                    content.insertAt(insertIndex, doc._internalModel);
+                                }
+                            }
+                        });
+                    });
+                    const onChildRemoved = ref.on('child_removed', snapshot => {
+                        run(() => {
+                            if (snapshot) {
+                                const record = content.find((record:any) => record.id === snapshot.key)
+                                if (record) { content.removeObject(record); }
+                            }
+                        });
+                    });
+                    const onChildChanged = ref.on('child_changed', snapshot => {
+                        run(() => {
+                            if (snapshot) {
+                                const normalizedData = serializer.normalizeSingleResponse(store, modelClass, snapshot);
+                                store.push(normalizedData);
+                            }
+                        });
+                    });
+                    const onChildMoved = ref.on('child_moved', (snapshot, priorKey) => {
+                        run(() => {
+                            if (snapshot) {
+                                const normalizedData = serializer.normalizeSingleResponse(store, modelClass, snapshot);
+                                const doc = store.push(normalizedData) as any;
+                                const existing = content.find((record:any) => record.id === doc.id);
+                                if (existing) { content.removeObject(existing); }
+                                if (priorKey) {
+                                    const record = content.find((record:any) => record.id === priorKey);
+                                    const index = content.indexOf(record);
+                                    content.insertAt(index+1, doc._internalModel);
+                                } else {
+                                    content.insertAt(0, doc._internalModel);
+                                }
+                            }
+                        });
+                    });
+                    const unsubscribe = () => {
+                        ref.off('child_added', onChildAdded);
+                        ref.off('child_removed', onChildRemoved);
+                        ref.off('child_changed', onChildChanged);
+                        ref.off('child_moved', onChildMoved);
+                    }
                     setRouteSubscription(this, route, uniqueIdentifier, unsubscribe);
                 });
             }
@@ -173,105 +251,6 @@ export default class RealtimeListenerService extends Service.extend({
         unsubscribeRoute(this, route, model && model.toString());
     }
 
-}
-
-const runFirestoreCollectionListener = ({query, model, store, serializer, modelClass}: FirestoreQueryArgs) => {
-    const unsubscribe = query.onSnapshot(snapshot => {
-        snapshot.docChanges().forEach(change => run(() => {
-            const normalizedData = serializer.normalizeSingleResponse(store, modelClass, change.doc);
-            switch(change.type) {
-                case 'added': {
-                    const current = model.content.objectAt(change.newIndex);
-                    if (current == null || current.id !== change.doc.id ) {
-                        const doc = store.push(normalizedData) as any;
-                        model.content.insertAt(change.newIndex, doc._internalModel);
-                    }
-                    break;
-                }
-                case 'modified': {
-                    const current = model.content.objectAt(change.oldIndex);
-                    if (current == null || current.id == change.doc.id) {
-                        if (change.newIndex !== change.oldIndex) {
-                            model.content.removeAt(change.oldIndex);
-                            model.content.insertAt(change.newIndex, current)
-                        }
-                    }
-                    store.push(normalizedData);
-                    break;
-                }
-                case 'removed': {
-                    const current = model.content.objectAt(change.oldIndex);
-                    if (current && current.id == change.doc.id) {
-                        model.content.removeAt(change.oldIndex);
-                    }
-                    break;
-                }
-            }
-        }))
-    });
-    return unsubscribe;
-}
-
-const runRealtimeDatabaseListListener = ({model, ref, serializer, store, modelClass}: RealtimeDatabaseQueryArgs) => {
-    const onChildAdded = ref.on('child_added', (snapshot, priorKey) => {
-        run(() => {
-            if (snapshot) {
-                const normalizedData = serializer.normalizeSingleResponse(store, modelClass, snapshot);
-                const doc = store.push(normalizedData) as any;
-                const existing = model.content.find((record:any) => record.id === doc.id);
-                if (existing) { model.content.removeObject(existing); }
-                let insertIndex = 0;
-                if (priorKey) {
-                    const record = model.content.find((record:any) => record.id === priorKey);
-                    insertIndex = model.content.indexOf(record) + 1;
-                }
-                const current = model.content.objectAt(insertIndex);
-                if (current == null || current.id !== doc.id ) {
-                    model.content.insertAt(insertIndex, doc._internalModel);
-                }
-            }
-        });
-    });
-    const onChildRemoved = ref.on('child_removed', snapshot => {
-        run(() => {
-            if (snapshot) {
-                const record = model.content.find((record:any) => record.id === snapshot.key)
-                if (record) { model.content.removeObject(record); }
-            }
-        });
-    });
-    const onChildChanged = ref.on('child_changed', snapshot => {
-        run(() => {
-            if (snapshot) {
-                const normalizedData = serializer.normalizeSingleResponse(store, modelClass, snapshot);
-                store.push(normalizedData);
-            }
-        });
-    });
-    const onChildMoved = ref.on('child_moved', (snapshot, priorKey) => {
-        run(() => {
-            if (snapshot) {
-                const normalizedData = serializer.normalizeSingleResponse(store, modelClass, snapshot);
-                const doc = store.push(normalizedData) as any;
-                const existing = model.content.find((record:any) => record.id === doc.id);
-                if (existing) { model.content.removeObject(existing); }
-                if (priorKey) {
-                    const record = model.content.find((record:any) => record.id === priorKey);
-                    const index = model.content.indexOf(record);
-                    model.content.insertAt(index+1, doc._internalModel);
-                } else {
-                    model.content.insertAt(0, doc._internalModel);
-                }
-            }
-        });
-    });
-    const unsubscribe = () => {
-        ref.off('child_added', onChildAdded);
-        ref.off('child_removed', onChildRemoved);
-        ref.off('child_changed', onChildChanged);
-        ref.off('child_moved', onChildMoved);
-    }
-    return unsubscribe;
 }
 
 declare module '@ember/service' {

--- a/addon/services/realtime-listener.ts
+++ b/addon/services/realtime-listener.ts
@@ -49,10 +49,6 @@ const unsubscribeRoute = (service: RealtimeListenerService, route: Object, uniqu
     }
 }
 
-function isFirestoreQuery(arg: any): arg is firestore.Query {
-    return arg.onSnapshot !== undefined;
-}
-
 function isFirestoreDocumentRefernce(arg: any): arg is firestore.DocumentReference {
     return arg.onSnapshot !== undefined;
 }
@@ -95,7 +91,7 @@ export default class RealtimeListenerService extends Service.extend({
             }
             internalModel[proxyPromiseListenersKey] = [
                 ...internalModel[proxyPromiseListenersKey],
-                ((kind: string, key: string, args: Object, result: any) => {
+                ((_kind: string, key: string, _args: Object, result: any) => {
                     const triggerdRelationship = modelClass.relationshipsObject[key];
                     this.subscribe(route, result, model, triggerdRelationship);
                 })

--- a/addon/session-stores/firebase.ts
+++ b/addon/session-stores/firebase.ts
@@ -1,15 +1,10 @@
 import Evented from '@ember/object/evented';
 import EmberObject from '@ember/object';
-
 import { get, set } from '@ember/object';
-import RSVP from 'rsvp';
-
+import { Promise, resolve } from 'rsvp';
 import Ember from 'ember';
 import FirebaseAppService from '../services/firebase-app';
-
-const { Promise, resolve } = RSVP;
 import { run } from '@ember/runloop';
-
 import { inject as service } from '@ember/service';
 
 export default class FirebaseSessionStore extends EmberObject.extend(Evented, {

--- a/addon/torii-adapters/firebase.ts
+++ b/addon/torii-adapters/firebase.ts
@@ -1,15 +1,10 @@
 import EmberObject from '@ember/object';
 import { inject as service } from '@ember/service';
-
 import { get } from '@ember/object';
-import RSVP from 'rsvp';
-
+import { Promise, reject, resolve } from 'rsvp';
 import Ember from 'ember';
 import FirebaseAppService from '../services/firebase-app';
-
-const { Promise, reject } = RSVP;
 import { run } from '@ember/runloop';
-import { resolve } from 'path';
 
 export default class FirebaseToriiAdapter extends EmberObject.extend({
     firebaseApp: service('firebase-app')

--- a/addon/torii-providers/firebase.ts
+++ b/addon/torii-providers/firebase.ts
@@ -1,7 +1,5 @@
 import EmberObject from '@ember/object';
-
-import RSVP from 'rsvp';
-const { reject } = RSVP;
+import { reject } from 'rsvp';
 
 export default class FirebaseToriiProvider extends EmberObject.extend({
 

--- a/docs/guide/analytics.md
+++ b/docs/guide/analytics.md
@@ -1,4 +1,4 @@
-# Authentication
+# Collect Analytics
 
 ## Collect Analytics data automatically with the `AnalyticsRouteMixin`
 
@@ -26,6 +26,34 @@ firebaseApp: service('firebase-app'),
 
 const analytics = await firebase.analytics();
 analytics.logEvent("some_event", { ... });
+```
+
+## Collect traces on route transistions automatically with `PerformanceRouteMixin`
+
+```js
+import PerformanceRouteMixin from 'emberfire/mixins/performance-route';
+import Route from '@ember/routing/route';
+
+export default Route.extend(PerformanceRouteMixin);
+```
+
+## Log traces with the `FirebaseApp` Service
+
+
+```js
+import { inject as service } from '@ember/service';
+
+...
+
+firebaseApp: service('firebase-app'),
+
+...
+
+const perf = await firebase.performance();
+const trace = perf.trace("some_event");
+trace.start();
+...
+trace.stop()
 ```
 
 ### Continue reading

--- a/mixins/performance-route.d.ts
+++ b/mixins/performance-route.d.ts
@@ -1,0 +1,7 @@
+import Mixin from '@ember/object/mixin';
+declare const _default: Mixin<{
+    firebaseApp: import("@ember/object/computed").default<import("../services/firebase-app").default, import("../services/firebase-app").default>;
+    router: import("@ember/object/computed").default<import("@ember/routing/router-service").default, import("@ember/routing/router-service").default>;
+    init(): void;
+}, import("@ember/object").default>;
+export default _default;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3012,6 +3012,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -11241,7 +11242,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -11259,11 +11261,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11276,15 +11280,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11387,7 +11394,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11397,6 +11405,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11409,17 +11418,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11436,6 +11448,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11508,7 +11521,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11518,6 +11532,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11593,7 +11608,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11623,6 +11639,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11640,6 +11657,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11678,11 +11696,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -14069,7 +14089,8 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build": "npm run ts:precompile && ember build",
-    "serve": "npm run build && node ./express.js",
+    "serve": "ember serve",
     "package": "npm run build && npm pack .",
     "test": "npm run ts:precompile && ember test",
     "ts:precompile": "ember ts:precompile",

--- a/tests/dummy/app/models/comment.js
+++ b/tests/dummy/app/models/comment.js
@@ -5,5 +5,5 @@ const { attr, belongsTo } = DS;
 export default DS.Model.extend({
     body: attr('string'),
     something: belongsTo('something'),
-    user: belongsTo('user')
+    user: belongsTo('user', { async: false })
 });

--- a/tests/dummy/app/models/comment.js
+++ b/tests/dummy/app/models/comment.js
@@ -5,5 +5,5 @@ const { attr, belongsTo } = DS;
 export default DS.Model.extend({
     body: attr('string'),
     something: belongsTo('something'),
-    user: belongsTo('user', { async: false })
+    user: belongsTo('user', { })
 });

--- a/tests/dummy/app/routes/comment.js
+++ b/tests/dummy/app/routes/comment.js
@@ -1,7 +1,8 @@
 import Route from '@ember/routing/route';
 import RealtimeRouteMixin from 'emberfire/mixins/realtime-route';
+import PerformanceRouteMixin from 'emberfire/mixins/performance-route';
 
-export default Route.extend(RealtimeRouteMixin, {
+export default Route.extend(RealtimeRouteMixin, PerformanceRouteMixin, {
     model(params) {
         return this.store.findRecord('comment', params.id, { include: 'user' });
     }

--- a/tests/dummy/app/routes/comments.js
+++ b/tests/dummy/app/routes/comments.js
@@ -1,8 +1,9 @@
 import Route from '@ember/routing/route';
 import RealtimeRouteMixin from 'emberfire/mixins/realtime-route';
 import { inject as service } from '@ember/service';
+import PerformanceRouteMixin from 'emberfire/mixins/performance-route';
 
-export default Route.extend(RealtimeRouteMixin, {
+export default Route.extend(RealtimeRouteMixin, PerformanceRouteMixin, {
     firebaseApp: service(),
     model() {
         return this.firebaseApp.auth().then(({currentUser}) => 

--- a/tests/dummy/app/routes/comments.js
+++ b/tests/dummy/app/routes/comments.js
@@ -7,8 +7,8 @@ export default Route.extend(RealtimeRouteMixin, {
     model() {
         return this.firebaseApp.auth().then(({currentUser}) => 
             currentUser &&
-                this.store.query('comment', { filter: { user: currentUser.uid }, include: 'user' }) ||
-                this.store.query('comment', { include: 'user'} )
+                this.store.query('comment', { filter: { user: currentUser.uid } }) ||
+                this.store.query('comment', { } )
         );
     }
 })  

--- a/tests/dummy/app/routes/something.js
+++ b/tests/dummy/app/routes/something.js
@@ -1,15 +1,13 @@
 import Route from '@ember/routing/route';
 import RealtimeRouteMixin from 'emberfire/mixins/realtime-route';
-import { subscribe, unsubscribe } from 'emberfire/services/realtime-listener';
 import { inject as service } from '@ember/service';
 import { get } from '@ember/object';
-import { resolve } from 'rsvp';
 
 export default Route.extend(RealtimeRouteMixin, {
     store: service(),
     firebaseApp: service(),
     model(params) {
-        return this.store.findRecord('something', params.id);
+        return this.store.findRecord('something', params.id, { include: 'user' });
     },
     actions: {
         createComment() {

--- a/tests/dummy/app/routes/something.js
+++ b/tests/dummy/app/routes/something.js
@@ -9,17 +9,14 @@ export default Route.extend(RealtimeRouteMixin, {
     store: service(),
     firebaseApp: service(),
     model(params) {
-        return this.store.query('comment', { filter: { something: params.id }, include: 'something'});
+        return this.store.findRecord('something', params.id);
     },
     actions: {
         createComment() {
             const store = get(this, 'store');
-            const somethingId = get(this, 'context.query.filter.something');
+            const something = get(this, 'context');
             const profile = get(this, 'firebaseApp').auth().then(({currentUser}) => currentUser && store.findRecord('user', currentUser.uid) || null);
-            Promise.all([
-                profile,
-                store.findRecord('something', somethingId),
-            ]).then(([user, something]) => {
+            profile.then((user) => {
                 return store.createRecord('comment', {
                     body: 'test',
                     user,

--- a/tests/dummy/app/routes/something.js
+++ b/tests/dummy/app/routes/something.js
@@ -2,8 +2,9 @@ import Route from '@ember/routing/route';
 import RealtimeRouteMixin from 'emberfire/mixins/realtime-route';
 import { inject as service } from '@ember/service';
 import { get } from '@ember/object';
+import PerformanceRouteMixin from 'emberfire/mixins/performance-route';
 
-export default Route.extend(RealtimeRouteMixin, {
+export default Route.extend(RealtimeRouteMixin, PerformanceRouteMixin, {
     store: service(),
     firebaseApp: service(),
     model(params) {

--- a/tests/dummy/app/routes/something.js
+++ b/tests/dummy/app/routes/something.js
@@ -9,7 +9,7 @@ export default Route.extend(RealtimeRouteMixin, {
     store: service(),
     firebaseApp: service(),
     model(params) {
-        return this.store.query('comment', { filter: { something: params.id }, include: 'user,something'});
+        return this.store.query('comment', { filter: { something: params.id }, include: 'something'});
     },
     actions: {
         createComment() {

--- a/tests/dummy/app/routes/somethings.js
+++ b/tests/dummy/app/routes/somethings.js
@@ -2,8 +2,9 @@ import Route from '@ember/routing/route';
 import RealtimeRouteMixin from 'emberfire/mixins/realtime-route';
 import { get } from '@ember/object';
 import { inject as service } from '@ember/service';
+import PerformanceRouteMixin from 'emberfire/mixins/performance-route';
 
-export default Route.extend(RealtimeRouteMixin, {
+export default Route.extend(RealtimeRouteMixin, PerformanceRouteMixin, {
     store: service(),
     firebaseApp: service(),
     model() {

--- a/tests/dummy/app/routes/user.js
+++ b/tests/dummy/app/routes/user.js
@@ -1,7 +1,8 @@
 import Route from '@ember/routing/route';
 import RealtimeRouteMixin from 'emberfire/mixins/realtime-route';
+import PerformanceRouteMixin from 'emberfire/mixins/performance-route';
 
-export default Route.extend(RealtimeRouteMixin, {
+export default Route.extend(RealtimeRouteMixin, PerformanceRouteMixin, {
     model(params) {
         return this.store.findRecord('user', params.id);
     }

--- a/tests/dummy/app/routes/user.js
+++ b/tests/dummy/app/routes/user.js
@@ -3,6 +3,6 @@ import RealtimeRouteMixin from 'emberfire/mixins/realtime-route';
 
 export default Route.extend(RealtimeRouteMixin, {
     model(params) {
-        return this.store.findRecord('user', params.id, {include: 'thoughts,comments,somethings'});
+        return this.store.findRecord('user', params.id);
     }
 });

--- a/tests/dummy/app/routes/users.js
+++ b/tests/dummy/app/routes/users.js
@@ -1,7 +1,8 @@
 import Route from '@ember/routing/route';
 import RealtimeRouteMixin from 'emberfire/mixins/realtime-route';
+import PerformanceRouteMixin from 'emberfire/mixins/performance-route';
 
-export default Route.extend(RealtimeRouteMixin, {
+export default Route.extend(RealtimeRouteMixin, PerformanceRouteMixin, {
     model() {
         return this.store.findAll('user');
     }

--- a/tests/dummy/app/templates/something.hbs
+++ b/tests/dummy/app/templates/something.hbs
@@ -1,7 +1,11 @@
 <p>{{#link-to 'somethings'}}Back to all{{/link-to}}</p>
 
+<h1>{{ model.title }}</h1>
+<p>{{#link-to "user" model.user.id }}{{ model.user.name }}{{/link-to}}</p>
+<em>{{ model.description }}</em>
+
 <ul>
-{{#each model as |comment|}}
+{{#each model.comments as |comment|}}
     <li>
         <p>{{ comment.body }}</p>
         {{#if comment.user}}<small>{{#link-to "user" comment.user.id}}{{comment.user.name}}{{/link-to}}</small>{{/if}}


### PR DESCRIPTION
Get the `RealtimeListenerService` to be able to stream updates to hasMany and belongsTo relationships. No API change.

Hacking `_internalModel._updatePromiseProxyFor` to get this done right now, as I haven't found a better API.