### PR TITLE
Changed command to create emberfire session-store for ember-simple-auth

### DIFF
--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -30,7 +30,7 @@ $ ember install ember-simple-auth
 In order to use Ember Simple Auth, we need to create a `app/session-stores/application.js` file with the following command:
 
 ```
-$ ember generate firebase-session-store session-store
+$ ember generate firebase-session-store application
 ```
 
 The next step is to enable an authentication provider in the Firebase Authentication panel, and enter the API key and secret for that provider. Details on enabling third-party providers can be found in our docs e.g. [Enabling Google Sign-In](https://firebase.google.com/docs/auth/web/google-signin).


### PR DESCRIPTION
### Description
Changed command to create emberfire session-store for ember-simple-auth to create session-store/application.js instead of session-store/session-store.js

The line right before the command describing the file we need to create is correct, only the command is mistaken.

### Code sample

Not Applicable
