### PR TITLE
Partially fixed many-to-many relationship issue

### DIFF
--- a/addon/adapters/firestore.ts
+++ b/addon/adapters/firestore.ts
@@ -134,7 +134,13 @@ export default class FirestoreAdapter extends DS.Adapter.extend({
         } else if (relationship.options.subcollection) {
             return docReference(this, relationship.parentModelName, snapshot.id).then(doc => queryDocs(doc.collection(collectionNameForType(relationship.type)), relationship.options.query));
         } else {
-            return rootCollection(this, relationship.type).then(collection => queryDocs(collection.where(relationship.parentModelName, '==', snapshot.id), relationship.options.query));
+            return rootCollection(this, relationship.type).then(collection => {
+							if (relationship.__inverseKey.slice(-1) === 's') {
+								return queryDocs(collection.where(relationship.__inverseKey, 'array-contains', snapshot.id), relationship.options.query);
+							} else {
+								return queryDocs(collection.where(relationship.parentModelName, '==', snapshot.id), relationship.options.query);
+							}
+            });
         }
     }
 


### PR DESCRIPTION
I think I have a fix for the many-to-many relationship issue people have been experiencing. Please don't merge this in though, as the code is pretty poor right now.  To complete the code we just need a good way of determining if a given relationship's inverse attribute is a belongsTo or a hasMany. Currently I am doing that by checking if the last character is an 's' or not, which obviously is less than ideal. But it does seem to work.

TLDR: This code will work in a pinch if your models follow standard inflection (e.g. "users/user", but not "people/person").